### PR TITLE
More ControlNet control

### DIFF
--- a/adetailer/args.py
+++ b/adetailer/args.py
@@ -54,8 +54,9 @@ class ADetailerArgs(BaseModel, extra=Extra.forbid):
     ad_use_cfg_scale: bool = False
     ad_cfg_scale: NonNegativeFloat = 7.0
     ad_restore_face: bool = False
-    ad_controlnet_model: constr(regex=r".*inpaint.*|^None$") = "None"
+    ad_controlnet_model: constr(regex=r".*(inpaint|tile|scribble|lineart|openpose).*|^None$") = "None"
     ad_controlnet_weight: confloat(ge=0.0, le=1.0) = 1.0
+    ad_controlnet_guidance_end: confloat(ge=0.0, le=1.0) = 1.0
 
     @staticmethod
     def ppop(
@@ -107,7 +108,7 @@ class ADetailerArgs(BaseModel, extra=Extra.forbid):
         ppop("ADetailer restore face")
         ppop(
             "ADetailer ControlNet model",
-            ["ADetailer ControlNet model", "ADetailer ControlNet weight"],
+            ["ADetailer ControlNet model", "ADetailer ControlNet weight", "ADetailer ControlNet guidance end"],
             cond="None",
         )
 
@@ -156,6 +157,7 @@ _all_args = [
     ("ad_restore_face", "ADetailer restore face"),
     ("ad_controlnet_model", "ADetailer ControlNet model"),
     ("ad_controlnet_weight", "ADetailer ControlNet weight"),
+    ("ad_controlnet_guidance_end", "ADetailer ControlNet guidance end"),
 ]
 
 AD_ENABLE = Arg(*_all_args[0])

--- a/adetailer/ui.py
+++ b/adetailer/ui.py
@@ -177,6 +177,17 @@ def one_ui_group(
             interactive=controlnet_exists,
             elem_id=eid("ad_controlnet_weight"),
         )
+        
+        w.ad_controlnet_guidance_end = gr.Slider(
+            label="ControlNet guidance end" + suffix(n),
+            minimum=0.0,
+            maximum=1.0,
+            step=0.05,
+            value=1.0,
+            visible=True,
+            interactive=controlnet_exists,
+            elem_id=eid("ad_controlnet_guidance_end"),
+        )
 
     for attr in ALL_ARGS.attrs:
         widget = getattr(w, attr)

--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -138,7 +138,7 @@ class AfterDetailerScript(scripts.Script):
             and args.ad_controlnet_model != "None"
         ):
             self.controlnet_ext.update_scripts_args(
-                p, args.ad_controlnet_model, args.ad_controlnet_weight
+                p, args.ad_controlnet_model, args.ad_controlnet_weight, args.ad_controlnet_guidance_end
             )
 
     def is_ad_enabled(self, *args_) -> bool:


### PR DESCRIPTION
I added the `controlnet_guidance_end` setting alongside the `controlnet_weight` one, as it is often beneficial to stop the guidance around `0.2` to `0.5` to give more leeway at higher denoise.

I also added support for ControlNet models tile, openpose, scribble, and lineart. Those are generally great at keeping a face orientation at a higher denoise like `0.8`. Combined with the previous setting it allows the user to have more variation on a face, but still keeping the overall composition.

To keep the settings simple, I propose to associate a single module to each model : 
 - inpaint : `inpaint_global_harmonious` (as it is already right now)
 - tile : `None` (could be `tile_resample` at `1.0`, same effect)
 - lineart : `lineart_coarse` (generally good at keeping composition, without too much details)
 - scribble : `t2ia_sketch_pidi` (same reason)
 - openpose : `openpose_full` (this allows it to be used on face, person, or hand)