### PR TITLE
Feature Addition: Customizable Noise Multiplier (#148)

### DIFF
--- a/adetailer/args.py
+++ b/adetailer/args.py
@@ -37,6 +37,8 @@ class ADetailerArgs(BaseModel, extra=Extra.forbid):
     ad_model: str = "None"
     ad_prompt: str = ""
     ad_negative_prompt: str = ""
+    ad_use_initial_noise_multiplier: bool = False
+    ad_initial_noise_multiplier: confloat(ge=0.5, le=1.5) = 1
     ad_confidence: confloat(ge=0.0, le=1.0) = 0.3
     ad_mask_min_ratio: confloat(ge=0.0, le=1.0) = 0.0
     ad_mask_max_ratio: confloat(ge=0.0, le=1.0) = 1.0
@@ -149,6 +151,8 @@ _all_args = [
     ("ad_model", "ADetailer model"),
     ("ad_prompt", "ADetailer prompt"),
     ("ad_negative_prompt", "ADetailer negative prompt"),
+    ("ad_use_initial_noise_multiplier", "ADetailer use separate Noise Multiplier for img2img"),
+    ("ad_initial_noise_multiplier", "ADetailer Noise Multiplier for img2img"),
     ("ad_confidence", "ADetailer confidence"),
     ("ad_mask_min_ratio", "ADetailer mask min ratio"),
     ("ad_mask_max_ratio", "ADetailer mask max ratio"),

--- a/adetailer/args.py
+++ b/adetailer/args.py
@@ -151,7 +151,10 @@ _all_args = [
     ("ad_model", "ADetailer model"),
     ("ad_prompt", "ADetailer prompt"),
     ("ad_negative_prompt", "ADetailer negative prompt"),
-    ("ad_use_initial_noise_multiplier", "ADetailer use separate Noise Multiplier for img2img"),
+    (
+        "ad_use_initial_noise_multiplier",
+        "ADetailer use separate Noise Multiplier for img2img",
+    ),
     ("ad_initial_noise_multiplier", "ADetailer Noise Multiplier for img2img"),
     ("ad_confidence", "ADetailer confidence"),
     ("ad_mask_min_ratio", "ADetailer mask min ratio"),

--- a/adetailer/args.py
+++ b/adetailer/args.py
@@ -37,8 +37,6 @@ class ADetailerArgs(BaseModel, extra=Extra.forbid):
     ad_model: str = "None"
     ad_prompt: str = ""
     ad_negative_prompt: str = ""
-    ad_use_initial_noise_multiplier: bool = False
-    ad_initial_noise_multiplier: confloat(ge=0.5, le=1.5) = 1
     ad_confidence: confloat(ge=0.0, le=1.0) = 0.3
     ad_mask_min_ratio: confloat(ge=0.0, le=1.0) = 0.0
     ad_mask_max_ratio: confloat(ge=0.0, le=1.0) = 1.0
@@ -57,6 +55,8 @@ class ADetailerArgs(BaseModel, extra=Extra.forbid):
     ad_steps: PositiveInt = 28
     ad_use_cfg_scale: bool = False
     ad_cfg_scale: NonNegativeFloat = 7.0
+    ad_use_noise_multiplier: bool = False
+    ad_noise_multiplier: confloat(ge=0.5, le=1.5) = 1.0
     ad_restore_face: bool = False
     ad_controlnet_model: constr(regex=cn_model_regex) = "None"
     ad_controlnet_weight: confloat(ge=0.0, le=1.0) = 1.0
@@ -151,11 +151,6 @@ _all_args = [
     ("ad_model", "ADetailer model"),
     ("ad_prompt", "ADetailer prompt"),
     ("ad_negative_prompt", "ADetailer negative prompt"),
-    (
-        "ad_use_initial_noise_multiplier",
-        "ADetailer use separate Noise Multiplier for img2img",
-    ),
-    ("ad_initial_noise_multiplier", "ADetailer Noise Multiplier for img2img"),
     ("ad_confidence", "ADetailer confidence"),
     ("ad_mask_min_ratio", "ADetailer mask min ratio"),
     ("ad_mask_max_ratio", "ADetailer mask max ratio"),
@@ -174,6 +169,8 @@ _all_args = [
     ("ad_steps", "ADetailer steps"),
     ("ad_use_cfg_scale", "ADetailer use separate CFG scale"),
     ("ad_cfg_scale", "ADetailer CFG scale"),
+    ("ad_use_noise_multiplier", "ADetailer use separate noise multiplier"),
+    ("ad_noise_multiplier", "ADetailer noise multiplier"),
     ("ad_restore_face", "ADetailer restore face"),
     ("ad_controlnet_model", "ADetailer ControlNet model"),
     ("ad_controlnet_weight", "ADetailer ControlNet weight"),

--- a/adetailer/ui.py
+++ b/adetailer/ui.py
@@ -402,7 +402,7 @@ def inpainting(w: Widgets, n: int, is_img2img: bool):
                 )
 
                 w.ad_initial_noise_multiplier = gr.Slider(
-                    label="Inpaint noise multiplier" + suffix(n),
+                    label="Noise multiplier for img2img" + suffix(n),
                     minimum=0.5,
                     maximum=1.5,
                     step=0.01,

--- a/adetailer/ui.py
+++ b/adetailer/ui.py
@@ -399,6 +399,32 @@ def inpainting(w: Widgets, n: int, is_img2img: bool):
                 elem_id=eid("ad_restore_face"),
             )
 
+        with gr.Row():
+            with gr.Column(variant="compact"):
+                w.ad_use_initial_noise_multiplier = gr.Checkbox(
+                        label="Use separate noise multiplier" + suffix(n),
+                        value=False,
+                        visible=True,
+                        elem_id=eid("ad_use_initial_noise_multiplier"),
+                    )
+                
+                w.ad_initial_noise_multiplier = gr.Slider(
+                    label="Noise multiplier for img2img" + suffix(n),
+                    minimum=0.5,
+                    maximum=1.5,
+                    step=0.01,
+                    value=1.0,
+                    visible=True,
+                    elem_id=eid("ad_initial_noise_multiplier"),
+                )
+
+                w.ad_use_initial_noise_multiplier.change(
+                        gr_interactive,
+                        inputs=w.ad_use_initial_noise_multiplier,
+                        outputs=w.ad_initial_noise_multiplier,
+                        queue=False,
+                    )
+            
 
 def controlnet(w: Widgets, n: int, is_img2img: bool):
     eid = partial(elem_id, n=n, is_img2img=is_img2img)

--- a/adetailer/ui.py
+++ b/adetailer/ui.py
@@ -398,7 +398,7 @@ def inpainting(w: Widgets, n: int, is_img2img: bool):
                     label="Use separate noise multiplier" + suffix(n),
                     value=False,
                     visible=True,
-                    elem_id=eid("ad_use_initial_noise_multiplier"),
+                    elem_id=eid("ad_use_noise_multiplier"),
                 )
 
                 w.ad_initial_noise_multiplier = gr.Slider(
@@ -408,7 +408,7 @@ def inpainting(w: Widgets, n: int, is_img2img: bool):
                     step=0.01,
                     value=1.0,
                     visible=True,
-                    elem_id=eid("ad_initial_noise_multiplier"),
+                    elem_id=eid("ad_noise_multiplier"),
                 )
 
                 w.ad_use_initial_noise_multiplier.change(

--- a/adetailer/ui.py
+++ b/adetailer/ui.py
@@ -393,23 +393,16 @@ def inpainting(w: Widgets, n: int, is_img2img: bool):
                 )
 
         with gr.Row():
-            w.ad_restore_face = gr.Checkbox(
-                label="Restore faces after ADetailer" + suffix(n),
-                value=False,
-                elem_id=eid("ad_restore_face"),
-            )
-
-        with gr.Row():
             with gr.Column(variant="compact"):
                 w.ad_use_initial_noise_multiplier = gr.Checkbox(
-                        label="Use separate noise multiplier" + suffix(n),
-                        value=False,
-                        visible=True,
-                        elem_id=eid("ad_use_initial_noise_multiplier"),
-                    )
-                
+                    label="Use separate noise multiplier" + suffix(n),
+                    value=False,
+                    visible=True,
+                    elem_id=eid("ad_use_initial_noise_multiplier"),
+                )
+
                 w.ad_initial_noise_multiplier = gr.Slider(
-                    label="Noise multiplier for img2img" + suffix(n),
+                    label="Inpaint noise multiplier" + suffix(n),
                     minimum=0.5,
                     maximum=1.5,
                     step=0.01,
@@ -419,12 +412,18 @@ def inpainting(w: Widgets, n: int, is_img2img: bool):
                 )
 
                 w.ad_use_initial_noise_multiplier.change(
-                        gr_interactive,
-                        inputs=w.ad_use_initial_noise_multiplier,
-                        outputs=w.ad_initial_noise_multiplier,
-                        queue=False,
-                    )
-            
+                    gr_interactive,
+                    inputs=w.ad_use_initial_noise_multiplier,
+                    outputs=w.ad_initial_noise_multiplier,
+                    queue=False,
+                )
+
+            w.ad_restore_face = gr.Checkbox(
+                label="Restore faces after ADetailer" + suffix(n),
+                value=False,
+                elem_id=eid("ad_restore_face"),
+            )
+
 
 def controlnet(w: Widgets, n: int, is_img2img: bool):
     eid = partial(elem_id, n=n, is_img2img=is_img2img)

--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -342,7 +342,7 @@ class AfterDetailerScript(scripts.Script):
     def get_i2i_p(self, p, args: ADetailerArgs, image):
         seed, subseed = self.get_seed(p)
         width, height = self.get_width_height(p, args)
-        initial_noise_multiplier=self.get_initial_noise_multiplier(p, args)
+        initial_noise_multiplier = self.get_initial_noise_multiplier(p, args)
         steps = self.get_steps(p, args)
         cfg_scale = self.get_cfg_scale(p, args)
 

--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -281,10 +281,10 @@ class AfterDetailerScript(scripts.Script):
             return args.ad_cfg_scale
         return p.cfg_scale
 
-    def get_initial_noise_multiplier(self, p, args: ADetailerArgs) -> float:
-        if args.ad_use_initial_noise_multiplier:
-            return args.ad_initial_noise_multiplier
-        return p.initial_noise_multiplier
+    def get_initial_noise_multiplier(self, p, args: ADetailerArgs) -> float | None:
+        if args.ad_use_noise_multiplier:
+            return args.ad_noise_multiplier
+        return None
 
     def infotext(self, p) -> str:
         return create_infotext(
@@ -342,9 +342,9 @@ class AfterDetailerScript(scripts.Script):
     def get_i2i_p(self, p, args: ADetailerArgs, image):
         seed, subseed = self.get_seed(p)
         width, height = self.get_width_height(p, args)
-        initial_noise_multiplier = self.get_initial_noise_multiplier(p, args)
         steps = self.get_steps(p, args)
         cfg_scale = self.get_cfg_scale(p, args)
+        initial_noise_multiplier = self.get_initial_noise_multiplier(p, args)
 
         sampler_name = p.sampler_name
         if sampler_name in ["PLMS", "UniPC"]:
@@ -354,13 +354,13 @@ class AfterDetailerScript(scripts.Script):
             init_images=[image],
             resize_mode=0,
             denoising_strength=args.ad_denoising_strength,
-            initial_noise_multiplier=initial_noise_multiplier,
             mask=None,
             mask_blur=args.ad_mask_blur,
             inpainting_fill=1,
             inpaint_full_res=args.ad_inpaint_only_masked,
             inpaint_full_res_padding=args.ad_inpaint_only_masked_padding,
             inpainting_mask_invert=0,
+            initial_noise_multiplier=initial_noise_multiplier,
             sd_model=p.sd_model,
             outpath_samples=p.outpath_samples,
             outpath_grids=p.outpath_grids,

--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -281,6 +281,11 @@ class AfterDetailerScript(scripts.Script):
             return args.ad_cfg_scale
         return p.cfg_scale
 
+    def get_initial_noise_multiplier(self, p, args: ADetailerArgs) -> float:
+        if args.ad_use_initial_noise_multiplier:
+            return args.ad_initial_noise_multiplier
+        return p.initial_noise_multiplier
+
     def infotext(self, p) -> str:
         return create_infotext(
             p, p.all_prompts, p.all_seeds, p.all_subseeds, None, 0, 0
@@ -337,6 +342,7 @@ class AfterDetailerScript(scripts.Script):
     def get_i2i_p(self, p, args: ADetailerArgs, image):
         seed, subseed = self.get_seed(p)
         width, height = self.get_width_height(p, args)
+        initial_noise_multiplier=self.get_initial_noise_multiplier(p, args)
         steps = self.get_steps(p, args)
         cfg_scale = self.get_cfg_scale(p, args)
 
@@ -348,6 +354,7 @@ class AfterDetailerScript(scripts.Script):
             init_images=[image],
             resize_mode=0,
             denoising_strength=args.ad_denoising_strength,
+            initial_noise_multiplier=initial_noise_multiplier,
             mask=None,
             mask_blur=args.ad_mask_blur,
             inpainting_fill=1,


### PR DESCRIPTION
I'd like to submit a pull request for your review. Here are the details:

## Mentioned Issue:
#148

## Overview:
This pull request introduces a new feature that allows users to customize the noise multiplier. Previously, the noise multiplier for img2img for adetailer could not be modified by the user. With this addition, users can now change the noise multiplier separately for adetailer. This change is similar to other configurable parameters like cfg scale or others.

## Context:
The motivation behind this feature addition is to address an issue raised in #148. When the noise multiplier is set to x1.5, the adetailer inpainting process produces undesirable results.

## Testing:
I have thoroughly tested this feature and can confirm that it performs as expected. I haven't encountered any errors during testing.

The code has been carefully inserted in the appropriate order. However, if you believe it should be placed differently or in a specific order, please let me know so that I can make the necessary adjustments.

I would greatly appreciate your review and any feedback or suggestions you may have regarding this pull request. Thank you for your time and consideration.

![00035-3448428264](https://github.com/Bing-su/adetailer/assets/106813119/a0630326-2829-44c1-9dfa-e36526251fb2)

![00034-3448428264](https://github.com/Bing-su/adetailer/assets/106813119/eb520717-ca59-47b7-a72d-f40f155555ac)
