### PR TITLE
fix --controlnet-dir cli argument handling

### DIFF
--- a/controlnet_ext/controlnet_ext.py
+++ b/controlnet_ext/controlnet_ext.py
@@ -88,7 +88,7 @@ def get_cn_model_dirs() -> list[Path]:
     else:
         cn_model_dir_old = None
     ext_dir1 = shared.opts.data.get("control_net_models_path", "")
-    ext_dir2 = shared.opts.data.get("controlnet_dir", "")
+    ext_dir2 = getattr(shared.cmd_opts, "controlnet_dir", "")
 
     dirs = [cn_model_dir]
     for ext_dir in [cn_model_dir_old, ext_dir1, ext_dir2]:


### PR DESCRIPTION
Instead of a webui setting, "controlnet_dir" is a cli argument added in preload.py.