### PR TITLE
Separate CLIP skip setting

### DIFF
--- a/adetailer/args.py
+++ b/adetailer/args.py
@@ -67,6 +67,8 @@ class ADetailerArgs(BaseModel, extra=Extra.forbid):
     ad_controlnet_weight: confloat(ge=0.0, le=1.0) = 1.0
     ad_controlnet_guidance_start: confloat(ge=0.0, le=1.0) = 0.0
     ad_controlnet_guidance_end: confloat(ge=0.0, le=1.0) = 1.0
+    ad_use_clip_skip: bool = False
+    ad_clip_skip: int = 1
     is_api: bool = True
 
     @root_validator(skip_on_failure=True)
@@ -207,6 +209,8 @@ _all_args = [
     ("ad_controlnet_weight", "ADetailer ControlNet weight"),
     ("ad_controlnet_guidance_start", "ADetailer ControlNet guidance start"),
     ("ad_controlnet_guidance_end", "ADetailer ControlNet guidance end"),
+    ("ad_use_clip_skip", "ADetailer use separate CLIP skip"),
+    ("ad_clip_skip", "ADetailer CLIP skip"),
 ]
 
 AD_ENABLE = Arg(*_all_args[0])

--- a/adetailer/args.py
+++ b/adetailer/args.py
@@ -12,6 +12,7 @@ from pydantic import (
     NonNegativeInt,
     PositiveInt,
     confloat,
+    conint,
     constr,
     root_validator,
     validator,
@@ -61,14 +62,14 @@ class ADetailerArgs(BaseModel, extra=Extra.forbid):
     ad_sampler: str = "DPM++ 2M Karras"
     ad_use_noise_multiplier: bool = False
     ad_noise_multiplier: confloat(ge=0.5, le=1.5) = 1.0
+    ad_use_clip_skip: bool = False
+    ad_clip_skip: conint(ge=1, le=12) = 1
     ad_restore_face: bool = False
     ad_controlnet_model: constr(regex=cn_model_regex) = "None"
     ad_controlnet_module: Optional[constr(regex=r".*inpaint.*|^None$")] = None
     ad_controlnet_weight: confloat(ge=0.0, le=1.0) = 1.0
     ad_controlnet_guidance_start: confloat(ge=0.0, le=1.0) = 0.0
     ad_controlnet_guidance_end: confloat(ge=0.0, le=1.0) = 1.0
-    ad_use_clip_skip: bool = False
-    ad_clip_skip: int = 1
     is_api: bool = True
 
     @root_validator(skip_on_failure=True)
@@ -142,6 +143,11 @@ class ADetailerArgs(BaseModel, extra=Extra.forbid):
             ["ADetailer use separate noise multiplier", "ADetailer noise multiplier"],
         )
 
+        ppop(
+            "ADetailer use separate CLIP skip",
+            ["ADetailer use separate CLIP skip", "ADetailer CLIP skip"],
+        )
+
         ppop("ADetailer restore face")
         ppop(
             "ADetailer ControlNet model",
@@ -203,14 +209,14 @@ _all_args = [
     ("ad_sampler", "ADetailer sampler"),
     ("ad_use_noise_multiplier", "ADetailer use separate noise multiplier"),
     ("ad_noise_multiplier", "ADetailer noise multiplier"),
+    ("ad_use_clip_skip", "ADetailer use separate CLIP skip"),
+    ("ad_clip_skip", "ADetailer CLIP skip"),
     ("ad_restore_face", "ADetailer restore face"),
     ("ad_controlnet_model", "ADetailer ControlNet model"),
     ("ad_controlnet_module", "ADetailer ControlNet module"),
     ("ad_controlnet_weight", "ADetailer ControlNet weight"),
     ("ad_controlnet_guidance_start", "ADetailer ControlNet guidance start"),
     ("ad_controlnet_guidance_end", "ADetailer ControlNet guidance end"),
-    ("ad_use_clip_skip", "ADetailer use separate CLIP skip"),
-    ("ad_clip_skip", "ADetailer CLIP skip"),
 ]
 
 AD_ENABLE = Arg(*_all_args[0])

--- a/adetailer/ui.py
+++ b/adetailer/ui.py
@@ -457,12 +457,37 @@ def inpainting(w: Widgets, n: int, is_img2img: bool, samplers: list[str]):
                 )
 
         with gr.Row():
-            w.ad_restore_face = gr.Checkbox(
-                label="Restore faces after ADetailer" + suffix(n),
-                value=False,
-                elem_id=eid("ad_restore_face"),
-            )
+            with gr.Column(variant="compact"):
+                w.ad_restore_face = gr.Checkbox(
+                    label="Restore faces after ADetailer" + suffix(n),
+                    value=False,
+                    elem_id=eid("ad_restore_face"),
+                )
 
+            with gr.Column(variant="compact"):
+                w.ad_use_clip_skip = gr.Checkbox(
+                    label="Use separate CLIP skip" + suffix(n),
+                    value=False,
+                    visible=True,
+                    elem_id=eid("ad_use_clip_skip"),
+                )
+
+                w.ad_clip_skip = gr.Slider(
+                    label="ADetailer CLIP skip" + suffix(n),
+                    minimum=1,
+                    maximum=12,
+                    step=1,
+                    value=1,
+                    visible=True,
+                    elem_id=eid("ad_clip_skip"),
+                )
+
+                w.ad_use_clip_skip.change(
+                    gr_interactive,
+                    inputs=w.ad_use_clip_skip,
+                    outputs=w.ad_clip_skip,
+                    queue=False,
+                )
 
 def controlnet(w: Widgets, n: int, is_img2img: bool):
     eid = partial(elem_id, n=n, is_img2img=is_img2img)

--- a/adetailer/ui.py
+++ b/adetailer/ui.py
@@ -489,6 +489,7 @@ def inpainting(w: Widgets, n: int, is_img2img: bool, samplers: list[str]):
                     queue=False,
                 )
 
+
 def controlnet(w: Widgets, n: int, is_img2img: bool):
     eid = partial(elem_id, n=n, is_img2img=is_img2img)
     cn_models = ["None", *get_cn_models()]

--- a/adetailer/ui.py
+++ b/adetailer/ui.py
@@ -458,13 +458,6 @@ def inpainting(w: Widgets, n: int, is_img2img: bool, samplers: list[str]):
 
         with gr.Row():
             with gr.Column(variant="compact"):
-                w.ad_restore_face = gr.Checkbox(
-                    label="Restore faces after ADetailer" + suffix(n),
-                    value=False,
-                    elem_id=eid("ad_restore_face"),
-                )
-
-            with gr.Column(variant="compact"):
                 w.ad_use_clip_skip = gr.Checkbox(
                     label="Use separate CLIP skip" + suffix(n),
                     value=False,
@@ -487,6 +480,13 @@ def inpainting(w: Widgets, n: int, is_img2img: bool, samplers: list[str]):
                     inputs=w.ad_use_clip_skip,
                     outputs=w.ad_clip_skip,
                     queue=False,
+                )
+
+            with gr.Column(variant="compact"):
+                w.ad_restore_face = gr.Checkbox(
+                    label="Restore faces after ADetailer" + suffix(n),
+                    value=False,
+                    elem_id=eid("ad_restore_face"),
                 )
 
 

--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -305,6 +305,11 @@ class AfterDetailerScript(scripts.Script):
         if sampler_name in ["PLMS", "UniPC"]:
             sampler_name = "Euler"
         return sampler_name
+    
+    def get_clip_skip(self, p, args: ADetailerArgs) -> int:
+        if args.ad_use_clip_skip:
+            return args.ad_clip_skip
+        return opts.data.get('CLIP_stop_at_last_layers', 1)
 
     def get_initial_noise_multiplier(self, p, args: ADetailerArgs) -> float | None:
         if args.ad_use_noise_multiplier:
@@ -372,6 +377,7 @@ class AfterDetailerScript(scripts.Script):
         cfg_scale = self.get_cfg_scale(p, args)
         initial_noise_multiplier = self.get_initial_noise_multiplier(p, args)
         sampler_name = self.get_sampler(p, args)
+        clip_skip = self.get_clip_skip(p, args)
 
         i2i = StableDiffusionProcessingImg2Img(
             init_images=[image],
@@ -407,6 +413,9 @@ class AfterDetailerScript(scripts.Script):
             extra_generation_params=p.extra_generation_params,
             do_not_save_samples=True,
             do_not_save_grid=True,
+            override_settings={
+                "CLIP_stop_at_last_layers": clip_skip
+            }
         )
 
         i2i.cached_c = [None, None]

--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -305,11 +305,11 @@ class AfterDetailerScript(scripts.Script):
         if sampler_name in ["PLMS", "UniPC"]:
             sampler_name = "Euler"
         return sampler_name
-    
+
     def get_clip_skip(self, p, args: ADetailerArgs) -> int:
         if args.ad_use_clip_skip:
             return args.ad_clip_skip
-        return opts.data.get('CLIP_stop_at_last_layers', 1)
+        return opts.data.get("CLIP_stop_at_last_layers", 1)
 
     def get_initial_noise_multiplier(self, p, args: ADetailerArgs) -> float | None:
         if args.ad_use_noise_multiplier:
@@ -413,9 +413,7 @@ class AfterDetailerScript(scripts.Script):
             extra_generation_params=p.extra_generation_params,
             do_not_save_samples=True,
             do_not_save_grid=True,
-            override_settings={
-                "CLIP_stop_at_last_layers": clip_skip
-            }
+            override_settings={"CLIP_stop_at_last_layers": clip_skip},
         )
 
         i2i.cached_c = [None, None]

--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -306,10 +306,11 @@ class AfterDetailerScript(scripts.Script):
             sampler_name = "Euler"
         return sampler_name
 
-    def get_clip_skip(self, p, args: ADetailerArgs) -> int:
+    def get_override_settings(self, p, args: ADetailerArgs) -> dict[str, Any]:
+        d = {}
         if args.ad_use_clip_skip:
-            return args.ad_clip_skip
-        return opts.data.get("CLIP_stop_at_last_layers", 1)
+            d["CLIP_stop_at_last_layers"] = args.ad_clip_skip
+        return d
 
     def get_initial_noise_multiplier(self, p, args: ADetailerArgs) -> float | None:
         if args.ad_use_noise_multiplier:
@@ -377,7 +378,7 @@ class AfterDetailerScript(scripts.Script):
         cfg_scale = self.get_cfg_scale(p, args)
         initial_noise_multiplier = self.get_initial_noise_multiplier(p, args)
         sampler_name = self.get_sampler(p, args)
-        clip_skip = self.get_clip_skip(p, args)
+        override_settings = self.get_override_settings(p, args)
 
         i2i = StableDiffusionProcessingImg2Img(
             init_images=[image],
@@ -413,7 +414,7 @@ class AfterDetailerScript(scripts.Script):
             extra_generation_params=p.extra_generation_params,
             do_not_save_samples=True,
             do_not_save_grid=True,
-            override_settings={"CLIP_stop_at_last_layers": clip_skip},
+            override_settings=override_settings,
         )
 
         i2i.cached_c = [None, None]


### PR DESCRIPTION
When using a LoRA or Textual Inversion on a face, it often happens that there is a precise CLIP skip where it is most potent.

With this setting you can have for example a CLIP skip set at 2 for the whole image for anime models, while still having it set at 1 only for the face. It really helps on the resemblance with many trainings.

![image](https://github.com/Bing-su/adetailer/assets/15424198/5bc3b887-e77c-4de6-9365-17f7f238e625)
