### PR TITLE
Masking only the top k largest predictions

### DIFF
--- a/adetailer/args.py
+++ b/adetailer/args.py
@@ -67,6 +67,7 @@ class ADetailerArgs(BaseModel, extra=Extra.forbid):
     ad_controlnet_weight: confloat(ge=0.0, le=1.0) = 1.0
     ad_controlnet_guidance_start: confloat(ge=0.0, le=1.0) = 0.0
     ad_controlnet_guidance_end: confloat(ge=0.0, le=1.0) = 1.0
+    ad_mask_k_largest: NonNegativeInt = 0
     is_api: bool = True
 
     @root_validator(skip_on_failure=True)
@@ -182,6 +183,7 @@ _all_args = [
     ("ad_confidence", "ADetailer confidence"),
     ("ad_mask_min_ratio", "ADetailer mask min ratio"),
     ("ad_mask_max_ratio", "ADetailer mask max ratio"),
+    ("ad_mask_k_largest", "ADetailer mask only top k largest"),
     ("ad_x_offset", "ADetailer x offset"),
     ("ad_y_offset", "ADetailer y offset"),
     ("ad_dilate_erode", "ADetailer dilate/erode"),

--- a/adetailer/mask.py
+++ b/adetailer/mask.py
@@ -216,7 +216,6 @@ def filter_by_ratio(pred: PredictOutput, low: float, high: float) -> PredictOutp
 
 
 def filter_take_largest(pred: PredictOutput, k: int) -> PredictOutput:
-    print(pred, k)
     if not pred.bboxes or k == 0:
         return pred
     areas = [bbox_area(bbox) for bbox in pred.bboxes]

--- a/adetailer/mask.py
+++ b/adetailer/mask.py
@@ -215,6 +215,17 @@ def filter_by_ratio(pred: PredictOutput, low: float, high: float) -> PredictOutp
     return pred
 
 
+def filter_take_largest(pred: PredictOutput, k: int) -> PredictOutput:
+    print(pred, k)
+    if not pred.bboxes or k == 0:
+        return pred
+    areas = [bbox_area(bbox) for bbox in pred.bboxes]
+    idx = np.argsort(areas)[-k:]
+    pred.bboxes = [pred.bboxes[i] for i in idx]
+    pred.masks = [pred.masks[i] for i in idx]
+    return pred
+
+
 # Merge / Invert
 def mask_merge(masks: list[Image.Image]) -> list[Image.Image]:
     arrs = [np.array(m) for m in masks]

--- a/adetailer/ui.py
+++ b/adetailer/ui.py
@@ -194,7 +194,7 @@ def detection(w: Widgets, n: int, is_img2img: bool):
     eid = partial(elem_id, n=n, is_img2img=is_img2img)
 
     with gr.Row():
-        with gr.Column():
+        with gr.Column(variant="compact"):
             w.ad_confidence = gr.Slider(
                 label="Detection model confidence threshold" + suffix(n),
                 minimum=0.0,
@@ -203,6 +203,15 @@ def detection(w: Widgets, n: int, is_img2img: bool):
                 value=0.3,
                 visible=True,
                 elem_id=eid("ad_confidence"),
+            )
+            w.ad_mask_k_largest = gr.Slider(
+                label="Mask only the top k largest (0 to disable)" + suffix(n),
+                minumum=0,
+                maximum=5,
+                step=1,
+                value=0,
+                visible=True,
+                elem_id=eid("ad_mask_k_largest")
             )
 
         with gr.Column(variant="compact"):
@@ -224,6 +233,7 @@ def detection(w: Widgets, n: int, is_img2img: bool):
                 visible=True,
                 elem_id=eid("ad_mask_max_ratio"),
             )
+
 
 
 def mask_preprocessing(w: Widgets, n: int, is_img2img: bool):

--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -26,7 +26,7 @@ from adetailer import (
 )
 from adetailer.args import ALL_ARGS, BBOX_SORTBY, ADetailerArgs, EnableChecker
 from adetailer.common import PredictOutput
-from adetailer.mask import filter_by_ratio, mask_preprocess, sort_bboxes
+from adetailer.mask import filter_take_largest, filter_by_ratio, mask_preprocess, sort_bboxes
 from adetailer.traceback import rich_traceback
 from adetailer.ui import adui, ordinal, suffix
 from controlnet_ext import ControlNetExt, controlnet_exists, get_cn_models
@@ -453,6 +453,7 @@ class AfterDetailerScript(scripts.Script):
         pred = filter_by_ratio(
             pred, low=args.ad_mask_min_ratio, high=args.ad_mask_max_ratio
         )
+        pred = filter_take_largest(pred, k=args.ad_mask_k_largest)
         pred = self.sort_bboxes(pred)
         return mask_preprocess(
             pred.masks,


### PR DESCRIPTION
The current YOLO predictions may not always be flawless, especially in scenarios where numerous characters appear in the background. To address this, we have introduced a valuable enhancement that enables users to mask only the largest predictions, thereby reducing unwanted background character masking, especially when employing a character LORA.

Key Features:

- A new slider has been added to the Detection tab, empowering users to control the number of top predictions to be considered.
- By setting the slider to 0, users can opt to apply no filtering and keep all predictions intact.

This feature aims to enhance the overall usability and efficiency of the detection process, providing users with a more flexible and accurate way to handle predictions. With the ability to selectively mask the largest predictions, the system can better handle complex scenes with cluttered backgrounds, improving the user experience and resulting in more precise character detection.