### PR TITLE
Populating i2i process with _ad_idx for extension compatibility

### DIFF
--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -420,6 +420,7 @@ class AfterDetailerScript(scripts.Script):
             override_settings=override_settings,
         )
 
+        i2i._ad_idx = p._ad_idx
         i2i.cached_c = [None, None]
         i2i.cached_uc = [None, None]
         i2i.scripts, i2i.script_args = self.script_filter(p, args)


### PR DESCRIPTION
Added a line to know which image we are inpainting in a batch for external extensions.

Without this, there isn't really a pretty way to know which image from a batch is being inpainted.