### PR TITLE
Adding AD S/R options to X/Y/Z plot

### DIFF
--- a/adetailer/args.py
+++ b/adetailer/args.py
@@ -70,6 +70,7 @@ class ADetailerArgs(BaseModel, extra=Extra.forbid):
     ad_use_clip_skip: bool = False
     ad_clip_skip: conint(ge=1, le=12) = 1
     ad_restore_face: bool = False
+    ad_prompt_replacements: list = []
     ad_controlnet_model: constr(regex=cn_model_regex) = "None"
     ad_controlnet_module: Optional[constr(regex=r".*inpaint.*|^None$")] = None
     ad_controlnet_weight: confloat(ge=0.0, le=1.0) = 1.0


### PR DESCRIPTION
This adds two new ADetailer specific options to the list of options for X/Y/Z plots:

* Prompt S/R (AD 1st)
* Prompt S/R (AD 1st and main prompt)

These work like the S/R functions provided in the XYZ extension natively, only applying to the first ADetailer prompt, or the first ADetailer prompt and the main prompt.