### PR TITLE
feat: Filter ultralytics detection by class

### DIFF
--- a/adetailer/args.py
+++ b/adetailer/args.py
@@ -41,6 +41,7 @@ class ADetailerArgs(BaseModel, extra=Extra.forbid):
     ad_prompt: str = ""
     ad_negative_prompt: str = ""
     ad_confidence: confloat(ge=0.0, le=1.0) = 0.3
+    ad_classes: int = 0
     ad_mask_k_largest: NonNegativeInt = 0
     ad_mask_min_ratio: confloat(ge=0.0, le=1.0) = 0.0
     ad_mask_max_ratio: confloat(ge=0.0, le=1.0) = 1.0
@@ -182,6 +183,7 @@ _all_args = [
     ("ad_prompt", "ADetailer prompt"),
     ("ad_negative_prompt", "ADetailer negative prompt"),
     ("ad_confidence", "ADetailer confidence"),
+    ("ad_classes", "ADetailer class filter"),
     ("ad_mask_k_largest", "ADetailer mask only top k largest"),
     ("ad_mask_min_ratio", "ADetailer mask min ratio"),
     ("ad_mask_max_ratio", "ADetailer mask max ratio"),

--- a/adetailer/ui.py
+++ b/adetailer/ui.py
@@ -226,6 +226,15 @@ def detection(w: Widgets, n: int, is_img2img: bool):
                 visible=True,
                 elem_id=eid("ad_confidence"),
             )
+            w.ad_classes = gr.Slider(
+                label="Class to detect" + suffix(n),
+                minimum=0,
+                maximum=600,
+                step=1,
+                value=0,
+                visible=True,
+                elem_id=eid("ad_classes"),
+            )
             w.ad_mask_k_largest = gr.Slider(
                 label="Mask only the top k largest (0 to disable)" + suffix(n),
                 minimum=0,

--- a/adetailer/ultralytics.py
+++ b/adetailer/ultralytics.py
@@ -14,6 +14,7 @@ def ultralytics_predict(
     model_path: str | Path,
     image: Image.Image,
     confidence: float = 0.3,
+    classes: int = 0,
     device: str = "",
 ) -> PredictOutput:
     from ultralytics import YOLO
@@ -21,7 +22,7 @@ def ultralytics_predict(
     model = YOLO(model_path)
     pred = model(image, conf=confidence, device=device)
 
-    bboxes = pred[0].boxes.xyxy.cpu().numpy()
+    bboxes = pred[0].boxes[pred[0].boxes.cls == classes].xyxy.cpu().numpy()
     if bboxes.size == 0:
         return PredictOutput()
     bboxes = bboxes.tolist()

--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -668,7 +668,7 @@ class AfterDetailerScript(scripts.Script):
             kwargs["device"] = self.ultralytics_device
 
         with change_torch_load():
-            pred = predictor(ad_model, pp.image, args.ad_confidence, **kwargs)
+            pred = predictor(ad_model, pp.image, args.ad_confidence, args.ad_classes, **kwargs)
 
         masks = self.pred_preprocessing(pred, args)
         shared.state.assign_current_image(pred.preview)


### PR DESCRIPTION
Hi!

I created this pull request to add the feature that I suggested in issue #376:

https://github.com/Bing-su/adetailer/issues/376

This feature adds the ability to apply inpainting on specific types of objects identified by Yolo v8. I tested this with the COCO and with the Open image v7 trained yolo v8 networks: 

https://github.com/ultralytics/assets/releases/download/v0.0.0/yolov8n.pt

https://github.com/ultralytics/assets/releases/download/v0.0.0/yolov8n-oiv7.pt

And it works very well for the wide range of objects that are recognized by these networks. The code simply adds a slider "Class to detect" to set which object to use. In the default 0 position it jut works as usual by recognising the first object.


