### PR TITLE
FEAT: add ability to invert paint top k.

### DIFF
--- a/adetailer/args.py
+++ b/adetailer/args.py
@@ -42,6 +42,7 @@ class ADetailerArgs(BaseModel, extra=Extra.forbid):
     ad_negative_prompt: str = ""
     ad_confidence: confloat(ge=0.0, le=1.0) = 0.3
     ad_mask_k_largest: NonNegativeInt = 0
+    ad_mask_k_largest_invert: bool = False
     ad_mask_min_ratio: confloat(ge=0.0, le=1.0) = 0.0
     ad_mask_max_ratio: confloat(ge=0.0, le=1.0) = 1.0
     ad_dilate_erode: int = 4
@@ -183,6 +184,7 @@ _all_args = [
     ("ad_negative_prompt", "ADetailer negative prompt"),
     ("ad_confidence", "ADetailer confidence"),
     ("ad_mask_k_largest", "ADetailer mask only top k largest"),
+    ("ad_mask_k_largest_invert", "Invert Mask Largest (Ignore largest mask areas)"),
     ("ad_mask_min_ratio", "ADetailer mask min ratio"),
     ("ad_mask_max_ratio", "ADetailer mask max ratio"),
     ("ad_x_offset", "ADetailer x offset"),

--- a/adetailer/mask.py
+++ b/adetailer/mask.py
@@ -215,12 +215,17 @@ def filter_by_ratio(pred: PredictOutput, low: float, high: float) -> PredictOutp
     return pred
 
 
-def filter_k_largest(pred: PredictOutput, k: int = 0) -> PredictOutput:
+def filter_k_largest(pred: PredictOutput, k: int = 0, invert: bool = False) -> PredictOutput:
     if not pred.bboxes or k == 0:
         return pred
     areas = [bbox_area(bbox) for bbox in pred.bboxes]
-    idx = np.argsort(areas)[-k:]
-    idx = idx[::-1]
+    if invert:
+        sorted_desc = np.argsort(areas)[::-1]
+        idx = sorted_desc[k:]
+        idx = idx[::-1]
+    else:
+        idx = np.argsort(areas)[-k:]
+        idx = idx[::-1]   
     pred.bboxes = [pred.bboxes[i] for i in idx]
     pred.masks = [pred.masks[i] for i in idx]
     return pred

--- a/adetailer/ui.py
+++ b/adetailer/ui.py
@@ -226,6 +226,14 @@ def detection(w: Widgets, n: int, is_img2img: bool):
                 visible=True,
                 elem_id=eid("ad_confidence"),
             )
+
+            w.ad_mask_k_largest_invert = gr.Checkbox(
+                label="Invert Mask Largest (Ignore largest)" + suffix(n),
+                value=False,
+                visible=True,
+                elem_id=eid("ad_mask_k_largest_invert"),
+            )
+
             w.ad_mask_k_largest = gr.Slider(
                 label="Mask only the top k largest (0 to disable)" + suffix(n),
                 minimum=0,

--- a/adetailer/ui.py
+++ b/adetailer/ui.py
@@ -228,7 +228,7 @@ def detection(w: Widgets, n: int, is_img2img: bool):
             )
 
             w.ad_mask_k_largest_invert = gr.Checkbox(
-                label="Invert Mask Largest (Ignore largest)" + suffix(n),
+                label="Invert Mask Top k (Ignore largest)" + suffix(n),
                 value=False,
                 visible=True,
                 elem_id=eid("ad_mask_k_largest_invert"),

--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -561,7 +561,7 @@ class AfterDetailerScript(scripts.Script):
         pred = filter_by_ratio(
             pred, low=args.ad_mask_min_ratio, high=args.ad_mask_max_ratio
         )
-        pred = filter_k_largest(pred, k=args.ad_mask_k_largest)
+        pred = filter_k_largest(pred, k=args.ad_mask_k_largest, invert = args.ad_mask_k_largest_invert)
         pred = self.sort_bboxes(pred)
         return mask_preprocess(
             pred.masks,


### PR DESCRIPTION
this adds the ability to invert painting the top K. this way we can paint background characters only while ignoring the main character who i usually inpaint manually.
for example: 

![image](https://github.com/Bing-su/adetailer/assets/17304343/2abcbb62-df99-4bd5-a04c-d31855f2b41f)

since invert is checked and top k is 1 it will paint everything but the largest mask.