### PR TITLE
:wrench: Support depth_hand_refiner ControlNet preprocessor

### DIFF
--- a/adetailer/args.py
+++ b/adetailer/args.py
@@ -18,8 +18,8 @@ from pydantic import (
     validator,
 )
 
-cn_model_regex = r".*(inpaint|tile|scribble|lineart|openpose).*|^None$"
-cn_module_regex = r".*(inpaint|tile|pidi|lineart|openpose).*|^None$"
+cn_model_regex = r".*(inpaint|tile|scribble|lineart|openpose|depth).*|^None$"
+cn_module_regex = r".*(inpaint|tile|pidi|lineart|openpose|depth).*|^None$"
 
 
 @dataclass

--- a/adetailer/ui.py
+++ b/adetailer/ui.py
@@ -26,6 +26,7 @@ cn_module_choices = {
     "openpose": ["openpose_full", "dw_openpose_full"],
     "tile": ["tile_resample", "tile_colorfix", "tile_colorfix+sharp"],
     "scribble": ["t2ia_sketch_pidi"],
+    "depth": ["depth_midas", "depth_hand_refiner"],
 }
 
 

--- a/controlnet_ext/controlnet_ext.py
+++ b/controlnet_ext/controlnet_ext.py
@@ -48,6 +48,7 @@ cn_model_module = {
     "lineart": "lineart_coarse",
     "openpose": "openpose_full",
     "tile": "tile_resample",
+    "depth": "depth_midas",
 }
 cn_model_regex = re.compile("|".join(cn_model_module.keys()))
 


### PR DESCRIPTION
Followup of https://github.com/Mikubill/sd-webui-controlnet/pull/2394.

This PR allows ADetailer use ControlNet depth model family to perform postprocess.

Usage example:
## Image generated without ADetailer
![00019-3875947387](https://github.com/Bing-su/adetailer/assets/20929282/b1b4222f-7005-47e4-bc70-efe4f9f76a96)

## Image generated with ADetailer
![00020-3875947387adetailer](https://github.com/Bing-su/adetailer/assets/20929282/da2027fb-e825-4f59-8854-b1d4f9150f53)

## ADetailer setting
![1704335057409](https://github.com/Bing-su/adetailer/assets/20929282/d0802eec-3f4b-4c27-8450-d266d951d655)

