### PR TITLE
save mask !adetailer.py

### DIFF
--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -706,6 +706,7 @@ class AfterDetailerScript(scripts.Script):
 
         p2 = copy(i2i)
         save_masks_only = opts.data.get("ad_save_mask_only", False)
+        skip_img2img = getattr(p, "_ad_skip_img2img", False)
         for j in range(steps):
             p2.image_mask = masks[j]
             p2.init_images[0] = self.ensure_rgb_image(p2.init_images[0])
@@ -720,8 +721,15 @@ class AfterDetailerScript(scripts.Script):
             try:
                 if not save_masks_only:
                     processed = process_images(p2)
-                else:
+                elif skip_img2img:
                     pp.image = copy(p2.image_mask)
+                else:
+                    self.save_image(
+                        p,
+                        p2.image_mask,
+                        condition="ad_save_mask_only",
+                        suffix="-ad-mask" + suffix(n, "-"),
+                    )
             except NansException as e:
                 msg = f"[-] ADetailer: 'NansException' occurred with {ordinal(n + 1)} settings.\n{e}"
                 print(msg, file=sys.stderr)


### PR DESCRIPTION
This is much better that than the last implementation I did.

Now if "Save mask image only" is checked in the settings masks will replace images in the outputs of img2img and make images with "-ad-mask" for txt2img. Use "Merge" to get everything in the mask. This is much faster.

Small optimization skipping copying initial image if not saving it. This should be done anyway as its free performance.