### PR TITLE
Fix ADetailer prompt in PNG Info showing the original prompt when ADetailer S/R script is applied

### DIFF
--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -648,6 +648,16 @@ class AfterDetailerScript(scripts.Script):
         if self.is_ad_enabled(*args_):
             arg_list = self.get_args(p, *args_)
             self.check_skip_img2img(p, *args_)
+
+            # The extra_generation_params has the ADetailer prompt that will be saved in the png info
+            # In case S/R script has been applied, we need to return the replaced prompt and not the original one
+            # batch_index exists on p if the p is for the Adetailer p.
+            # If the p is for the image before Adetailer, batch_index does not seem to exist.
+            if hasattr(p, "_ad_xyz_prompt_sr") and hasattr(p, "batch_index"):
+                replaced_positive_prompt, replaced_negative_prompt = self.get_prompt(p, arg_list[0])
+                arg_list[0].ad_prompt = replaced_positive_prompt[0]
+                arg_list[0].ad_negative_prompt = replaced_negative_prompt[0]
+
             extra_params = self.extra_params(arg_list)
             p.extra_generation_params.update(extra_params)
         else:


### PR DESCRIPTION
**Problem:** When you use ADetailer with [ADetailer] Prompt S/R (AD 1st and main prompt) script and save PNG Info in the image, the ADetailer prompt in the PNG Info is the original prompt and not the replaced one.

**Reproduction step:**
- main prompt: `<lora:SomeLora-000002:1>`
- Enable ADetailer
- ADetailer prompt: `<lora:SomeLora-000002:1>`
- Enable script [ADetailer] Prompt S/R (AD 1st and main prompt) and set the value to: 02,04

**Current behaviour when you look at the PNG Info saved in the image:**
parameters

`<lora:SomeLora-000004:1>`, main prompt
Negative prompt: worse quality, bad quality, lowres
Steps: 20, Sampler: DPM++ 2M Karras, CFG scale: 7, Seed: 4233913175, Size: 512x512, Model hash: 879db523c3, Model: dreamshaper_8, VAE hash: 735e4c3a44, VAE: vae-ft-mse-840000-ema-pruned.safetensors, ADetailer model: face_yolov8n.pt, ADetailer prompt: "`<lora:SomeLora-000002:1>`, adetailer prompt", ADetailer negative prompt: bad quality, ADetailer confidence: 0.3, ADetailer dilate erode: 4, ADetailer mask blur: 4, ADetailer denoising strength: 0.4, ADetailer inpaint only masked: True, ADetailer inpaint padding: 32, ADetailer version: 24.1.2, Lora hashes: `"SomeLora-000004`: 8d6c29c789ee", Version: v1.7.0

You can see that the main prompt is showing the replaced prompt. You can also see that the Lora Hash corresponds to the replaced lora. However, you can see that the ADetailer prompt is showing the original prompt.

**The new behaviour:**
parameters

`<lora:SomeLora-000004:1>`, main prompt
Negative prompt: worse quality, bad quality, lowres
Steps: 20, Sampler: DPM++ 2M Karras, CFG scale: 7, Seed: 4233913175, Size: 512x512, Model hash: 879db523c3, Model: dreamshaper_8, VAE hash: 735e4c3a44, VAE: vae-ft-mse-840000-ema-pruned.safetensors, ADetailer model: face_yolov8n.pt, ADetailer prompt: "`<lora:SomeLora-000004:1>`, adetailer prompt", ADetailer negative prompt: bad quality, ADetailer confidence: 0.3, ADetailer dilate erode: 4, ADetailer mask blur: 4, ADetailer denoising strength: 0.4, ADetailer inpaint only masked: True, ADetailer inpaint padding: 32, ADetailer version: 24.1.2, Lora hashes: "`SomeLora-000004`: 8d6c29c789ee", Version: v1.7.0

Now you can see that the ADetailer prompt is correctly showing the replaced prompt



**Solution:** use get_prompt to get the replaced prompts when setting extra parameters

