### PR TITLE
Adds a separate preprocessor default setting for controlnet hand refiner module

### DIFF
--- a/controlnet_ext/controlnet_ext.py
+++ b/controlnet_ext/controlnet_ext.py
@@ -46,6 +46,7 @@ cn_model_module = {
     "inpaint_depth_hand": "depth_hand_refiner",
     "inpaint": "inpaint_global_harmonious",
     "scribble": "t2ia_sketch_pidi",
+    "lineart_anime": "lineart_anime",
     "lineart": "lineart_coarse",
     "openpose": "openpose_full",
     "tile": "tile_resample",

--- a/controlnet_ext/controlnet_ext.py
+++ b/controlnet_ext/controlnet_ext.py
@@ -43,6 +43,7 @@ if controlnet_path is not None:
             sys.path.append(target_path)
 
 cn_model_module = {
+    "inpaint_depth_hand": "depth_hand_refiner",
     "inpaint": "inpaint_global_harmonious",
     "scribble": "t2ia_sketch_pidi",
     "lineart": "lineart_coarse",


### PR DESCRIPTION
This PR adds "inpaint_depth_hand" as its own class and identifies "depth_hand_refiner" as the default preprocessor. Fixes a very niche problem in A1111 1.7.0. 

Current Problem: When setting a new default controlnet model and preprocessor via ui-config or Settings>Defaults, only the controlnet model is actually set in a new A1111 instance. In this case, even after setting inpaint_depth_hand as the default model and depth_hand_refiner for 1st, opening a new instance and generating an image immediately will cause adetailer to (1) mistakenly identify the model as an inpaint model and (2) to use the inpaint_global_harmonious preprocessor. For days, I'd been running hand refiner with depth_midas preprocessor instead because of this A1111 bug, it was annoying.


Again, a very niche problem, I don't know how to code, I'm not sure if this affects other functionalities of adetailer. So far though, I haven't run into any issues. 

EDIT: Just noticed the same issue for lineart-anime, so I went and added that in too.