### PR TITLE
Enable controlnet when installed on forge

### DIFF
--- a/controlnet_ext/controlnet_ext.py
+++ b/controlnet_ext/controlnet_ext.py
@@ -29,7 +29,8 @@ for extension in extensions.active():
     if not extension.enabled:
         continue
     # For cases like sd-webui-controlnet-master
-    if "sd-webui-controlnet" in extension.name:
+    # For stable-diffusion-webui-forge
+    if "sd-webui-controlnet" in extension.name or extension.name == "sd_forge_controlnet":
         controlnet_exists = True
         controlnet_path = Path(extension.path)
         cn_base_path = ".".join(controlnet_path.parts[-2:])


### PR DESCRIPTION
I noticed that when I installed ADetailer on [forge](https://github.com/lllyasviel/stable-diffusion-webui-forge), the ControlNet settings are not loaded.

Upon investigation, I found that the reason was that [the name of the ControlNet extension](https://github.com/lllyasviel/stable-diffusion-webui-forge/tree/main/extensions-builtin/sd_forge_controlnet) was different from that of sd-webui, so I created a pull request to fix the problem.
