### PR TITLE
Made СontrolNet model RegEx case insensitive

### DIFF
--- a/controlnet_ext/common.py
+++ b/controlnet_ext/common.py
@@ -8,4 +8,4 @@ cn_model_module = {
     "tile": "tile_resample",
     "depth": "depth_midas",
 }
-cn_model_regex = re.compile("|".join(cn_model_module.keys()))
+cn_model_regex = re.compile("|".join(cn_model_module.keys()), flags=re.I)


### PR DESCRIPTION
Some ControlNet models are published with capital letters in the filename, which were not always previously discovered by the extension. 

This fix makes the regex case insensitive and broadens the models selected.