### PR TITLE
Add dynamic denoising and inpaint bbox sizing

### DIFF
--- a/adetailer/args.py
+++ b/adetailer/args.py
@@ -266,7 +266,7 @@ INPAINT_BBOX_MATCH_MODES = [
     "Off",
     "Strict (SDXL only)",
     "Free (prefer smaller sizes)",
-    "Free (prefer larger sizes)"
+    "Free (prefer larger sizes)",
 ]
 MASK_MERGE_INVERT = ["None", "Merge", "Merge and Invert"]
 

--- a/adetailer/args.py
+++ b/adetailer/args.py
@@ -262,6 +262,12 @@ BBOX_SORTBY = [
     "Position (center to edge)",
     "Area (large to small)",
 ]
+INPAINT_BBOX_MATCH_MODES = [
+    "Off",
+    "Strict (SDXL only)",
+    "Free (prefer smaller sizes)",
+    "Free (prefer larger sizes)"
+]
 MASK_MERGE_INVERT = ["None", "Merge", "Merge and Invert"]
 
 _script_default = (

--- a/adetailer/args.py
+++ b/adetailer/args.py
@@ -265,8 +265,7 @@ BBOX_SORTBY = [
 INPAINT_BBOX_MATCH_MODES = [
     "Off",
     "Strict (SDXL only)",
-    "Free (prefer smaller sizes)",
-    "Free (prefer larger sizes)",
+    "Free",
 ]
 MASK_MERGE_INVERT = ["None", "Merge", "Merge and Invert"]
 

--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -736,7 +736,7 @@ class AfterDetailerScript(scripts.Script):
             return (inpaint_width, inpaint_height)
 
         print(
-            f"[-] ADetailer: inpaint dimensions optimized -- {inpaint_width}x{inpaint_height} -> {optimal_resolution[0]:.0f}x{optimal_resolution[1]:.0f}"
+            f"[-] ADetailer: inpaint dimensions optimized -- {inpaint_width}x{inpaint_height} -> {optimal_resolution[0]}x{optimal_resolution[1]}"
         )
 
         return optimal_resolution

--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -838,7 +838,10 @@ class AfterDetailerScript(scripts.Script):
             p2.cached_uc = [None, None]
             
             p2.denoising_strength = self.get_dynamic_denoise_strength(p2.denoising_strength, pred.bboxes[j], pp.image)
-            p2.width, p2.height = self.get_optimal_crop_image_size(p2.width, p2.height, pred.bboxes[j])
+
+            # Don't override user-defined dimensions.
+            if not args.ad_use_inpaint_width_height:
+                p2.width, p2.height = self.get_optimal_crop_image_size(p2.width, p2.height, pred.bboxes[j])
 
             try:
                 processed = process_images(p2)

--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -672,7 +672,7 @@ class AfterDetailerScript(scripts.Script):
     @staticmethod
     def get_dynamic_denoise_strength(denoise_strength, bbox, image):
         denoise_power = opts.data.get("ad_dynamic_denoise_power", 0)
-        if math.isclose(denoise_power, 0):
+        if denoise_power == 0:
             return denoise_strength
 
         image_pixels = image.width * image.height

--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -41,8 +41,8 @@ from adetailer import (
 )
 from adetailer.args import (
     BBOX_SORTBY,
-    INPAINT_BBOX_MATCH_MODES,
     BUILTIN_SCRIPT,
+    INPAINT_BBOX_MATCH_MODES,
     SCRIPT_DEFAULT,
     ADetailerArgs,
     SkipImg2ImgOrig,
@@ -736,7 +736,11 @@ class AfterDetailerScript(scripts.Script):
         elif calculate_optimal_crop.startswith("Free"):
             prefer_larger = calculate_optimal_crop.endswith("(prefer larger sizes)")
 
-            scale_size = max(inpaint_width, inpaint_height) if prefer_larger else min(inpaint_width, inpaint_height)
+            scale_size = (
+                max(inpaint_width, inpaint_height)
+                if prefer_larger
+                else min(inpaint_width, inpaint_height)
+            )
 
             if bbox_aspect_ratio > 1:
                 optimal_width = scale_size * bbox_aspect_ratio
@@ -751,16 +755,17 @@ class AfterDetailerScript(scripts.Script):
 
             optimal_resolution = (int(optimal_width), int(optimal_height))
         else:
-            msg = (
-                "[-] ADetailer: unsupported inpaint bounding box match mode. Original inpainting dimensions will be used."
-            )
+            msg = "[-] ADetailer: unsupported inpaint bounding box match mode. Original inpainting dimensions will be used."
             print(msg)
 
         if optimal_resolution is None:
             return (inpaint_width, inpaint_height)
 
         # Only use optimal dimensions if they're different enough to current inpaint dimensions.
-        if (abs(optimal_resolution[0] - inpaint_width) > inpaint_width * 0.1 and abs(optimal_resolution[1] - inpaint_height) > inpaint_height * 0.1):
+        if (
+            abs(optimal_resolution[0] - inpaint_width) > inpaint_width * 0.1
+            and abs(optimal_resolution[1] - inpaint_height) > inpaint_height * 0.1
+        ):
             print(
                 f"[-] ADetailer: inpaint dimensions optimized -- {inpaint_width}x{inpaint_height} -> {optimal_resolution[0]}x{optimal_resolution[1]}"
             )

--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -733,21 +733,15 @@ class AfterDetailerScript(scripts.Script):
                 resolutions,
                 key=lambda res: abs((res[0] / res[1]) - bbox_aspect_ratio),
             )
-        elif calculate_optimal_crop.startswith("Free"):
-            prefer_larger = calculate_optimal_crop.endswith("(prefer larger sizes)")
-
-            scale_size = (
-                max(inpaint_width, inpaint_height)
-                if prefer_larger
-                else min(inpaint_width, inpaint_height)
-            )
+        elif calculate_optimal_crop == "Free":
+            scale_size = max(inpaint_width, inpaint_height)
 
             if bbox_aspect_ratio > 1:
+                optimal_width = scale_size
+                optimal_height = scale_size / bbox_aspect_ratio
+            else:
                 optimal_width = scale_size * bbox_aspect_ratio
                 optimal_height = scale_size
-            else:
-                optimal_height = scale_size / bbox_aspect_ratio
-                optimal_width = scale_size
 
             # Round up to the nearest multiple of 8 to make the dimensions friendly for upscaling/diffusion.
             optimal_width = ((optimal_width + 8 - 1) // 8) * 8
@@ -1052,7 +1046,7 @@ def on_ui_settings():
             label="Try to match inpainting size to bounding box size, if 'Use separate width/height' is not set",
             section=section,
         ).info(
-            "Strict is for SDXL only, and matches exactly to trained SDXL resolutions. Free works with any model, but will use potentially unsupported dimensions. Prefer smaller is more conservative and safer."
+            "Strict is for SDXL only, and matches exactly to trained SDXL resolutions. Free works with any model, but will use potentially unsupported dimensions."
         ),
     )
 

--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import platform
 import re
 import sys
@@ -13,7 +14,6 @@ from typing import TYPE_CHECKING, Any, NamedTuple, cast
 import gradio as gr
 from PIL import Image, ImageChops
 from rich import print
-import math
 
 import modules
 from aaaaaa.conditional import create_binary_mask, schedulers
@@ -681,8 +681,10 @@ class AfterDetailerScript(scripts.Script):
         normalized_area = bbox_pixels / image_pixels
         denoise_modifier = (1.0 - normalized_area) ** denoise_power
 
-        print((f"[-] ADetailer: dynamic denoising -- {denoise_modifier:.2f} * {denoise_strength:.2f} = {denoise_strength * denoise_modifier:.2f}"))
-        
+        print(
+            f"[-] ADetailer: dynamic denoising -- {denoise_modifier:.2f} * {denoise_strength:.2f} = {denoise_strength * denoise_modifier:.2f}"
+        )
+
         return denoise_strength * denoise_modifier
 
     @staticmethod
@@ -694,17 +696,19 @@ class AfterDetailerScript(scripts.Script):
         resolutions = []
         if shared.sd_model.is_sdxl:
             # Limit resolutions to those SDXL was trained on.
-            resolutions = [ 
+            resolutions = [
                 (1024, 1024),
-                (1152, 896), (896, 1152),
-                (1216, 832), (832, 1216),
-                (1344, 768), (768, 1344),
-                (1536, 640), (640, 1536)
+                (1152, 896),
+                (896, 1152),
+                (1216, 832),
+                (832, 1216),
+                (1344, 768),
+                (768, 1344),
+                (1536, 640),
+                (640, 1536),
             ]
         else:
-            msg = (
-                "[-] ADetailer: inpaint bounding box size matching is only valid for SDXL."
-            )
+            msg = "[-] ADetailer: inpaint bounding box size matching is only valid for SDXL."
             print(msg)
             return (inpaint_width, inpaint_height)
 
@@ -712,22 +716,29 @@ class AfterDetailerScript(scripts.Script):
         bbox_height = bbox[3] - bbox[1]
 
         target_aspect = bbox_width / bbox_height
-        larger_resolutions = [res for res in resolutions if res[0] >= bbox_width and res[1] >= bbox_height]
-        
+        larger_resolutions = [
+            res for res in resolutions if res[0] >= bbox_width and res[1] >= bbox_height
+        ]
+
         if not larger_resolutions:
             return (inpaint_width, inpaint_height)
-        
+
         def aspect_ratio_difference(res):
             res_aspect = res[0] / res[1]
             return abs(res_aspect - target_aspect)
-        
+
         optimal_resolution = min(larger_resolutions, key=aspect_ratio_difference)
 
         # Don't use resolution if it's smaller than what was to be used.
-        if optimal_resolution[0] < inpaint_width and optimal_resolution[1] < inpaint_height:
+        if (
+            optimal_resolution[0] < inpaint_width
+            and optimal_resolution[1] < inpaint_height
+        ):
             return (inpaint_width, inpaint_height)
-        
-        print((f"[-] ADetailer: inpaint dimensions optimized -- {inpaint_width}x{inpaint_height} -> {optimal_resolution[0]:.0f}x{optimal_resolution[1]:.0f}"))
+
+        print(
+            f"[-] ADetailer: inpaint dimensions optimized -- {inpaint_width}x{inpaint_height} -> {optimal_resolution[0]:.0f}x{optimal_resolution[1]:.0f}"
+        )
 
         return optimal_resolution
 
@@ -836,12 +847,16 @@ class AfterDetailerScript(scripts.Script):
 
             p2.cached_c = [None, None]
             p2.cached_uc = [None, None]
-            
-            p2.denoising_strength = self.get_dynamic_denoise_strength(p2.denoising_strength, pred.bboxes[j], pp.image)
+
+            p2.denoising_strength = self.get_dynamic_denoise_strength(
+                p2.denoising_strength, pred.bboxes[j], pp.image
+            )
 
             # Don't override user-defined dimensions.
             if not args.ad_use_inpaint_width_height:
-                p2.width, p2.height = self.get_optimal_crop_image_size(p2.width, p2.height, pred.bboxes[j])
+                p2.width, p2.height = self.get_optimal_crop_image_size(
+                    p2.width, p2.height, pred.bboxes[j]
+                )
 
             try:
                 processed = process_images(p2)
@@ -993,17 +1008,20 @@ def on_ui_settings():
             component=gr.Slider,
             component_args={"minimum": -10, "maximum": 10, "step": 0.01},
             section=section,
-        )
-        .info("Smaller areas get higher denoising, larger areas less. Maximum denoise strength is set by 'Inpaint denoising strength'. 0 = disabled; 1 = linear; 4 = recommended"),
+        ).info(
+            "Smaller areas get higher denoising, larger areas less. Maximum denoise strength is set by 'Inpaint denoising strength'. 0 = disabled; 1 = linear; 4 = recommended"
+        ),
     )
 
     shared.opts.add_option(
         "ad_match_inpaint_bbox_size",
         shared.OptionInfo(
-            False, "Try to match inpaint width, height and aspect ratio to bounding box size", section=section
-        )
-        .info("SDXL only, as it natively supports alternative aspect ratios"),
+            False,
+            "Try to match inpaint width, height and aspect ratio to bounding box size",
+            section=section,
+        ).info("SDXL only, as it natively supports alternative aspect ratios"),
     )
+
 
 # xyz_grid
 

--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -1008,7 +1008,7 @@ def on_ui_settings():
             component_args={"minimum": -10, "maximum": 10, "step": 0.01},
             section=section,
         ).info(
-            "Smaller areas get higher denoising, larger areas less. Maximum denoise strength is set by 'Inpaint denoising strength'. 0 = disabled; 1 = linear; 4 = recommended"
+            "Smaller areas get higher denoising, larger areas less. Maximum denoise strength is set by 'Inpaint denoising strength'. 0 = disabled; 1 = linear; 2-4 = recommended"
         ),
     )
 
@@ -1016,9 +1016,9 @@ def on_ui_settings():
         "ad_match_inpaint_bbox_size",
         shared.OptionInfo(
             False,
-            "Try to match inpaint width, height and aspect ratio to bounding box size",
+            "Try to match inpainting size to bounding box size, if 'Use separate width/height' is not set",
             section=section,
-        ).info("SDXL only, as it natively supports alternative aspect ratios"),
+        ).info("Works with SDXL only, as it natively supports alternative aspect ratios"),
     )
 
 

--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -41,6 +41,7 @@ from adetailer import (
 )
 from adetailer.args import (
     BBOX_SORTBY,
+    INPAINT_BBOX_MATCH_MODES,
     BUILTIN_SCRIPT,
     SCRIPT_DEFAULT,
     ADetailerArgs,
@@ -688,48 +689,78 @@ class AfterDetailerScript(scripts.Script):
 
     @staticmethod
     def get_optimal_crop_image_size(inpaint_width, inpaint_height, bbox):
-        calculate_optimal_crop = opts.data.get("ad_match_inpaint_bbox_size", False)
-        if not calculate_optimal_crop:
+        calculate_optimal_crop = opts.data.get("ad_match_inpaint_bbox_size", "Off")
+        if calculate_optimal_crop == "Off":
             return (inpaint_width, inpaint_height)
 
-        if not shared.sd_model.is_sdxl:
-            msg = "[-] ADetailer: inpaint bounding box size matching is only available for SDXL."
-            print(msg)
-            return (inpaint_width, inpaint_height)
+        optimal_resolution = None
 
         bbox_width = bbox[2] - bbox[0]
         bbox_height = bbox[3] - bbox[1]
+        bbox_aspect_ratio = bbox_width / bbox_height
 
-        # Limit resolutions to those SDXL was trained on.
-        resolutions = [
-            (1024, 1024),
-            (1152, 896),
-            (896, 1152),
-            (1216, 832),
-            (832, 1216),
-            (1344, 768),
-            (768, 1344),
-            (1536, 640),
-            (640, 1536),
-        ]
+        if calculate_optimal_crop == "Strict (SDXL only)":
+            if not shared.sd_model.is_sdxl:
+                msg = "[-] ADetailer: strict inpaint bounding box size matching is only available for SDXL. Use Free mode instead."
+                print(msg)
+                return (inpaint_width, inpaint_height)
 
-        # Filter resolutions smaller than bbox, and any that could result in a total pixel size smaller than the current inpaint dimensions.
-        resolutions = [
-            res
-            for res in resolutions
-            if (res[0] >= bbox_width and res[1] >= bbox_height)
-            and (res[0] >= inpaint_width or res[1] >= inpaint_height)
-        ]
+            # Limit resolutions to those SDXL was trained on.
+            resolutions = [
+                (1024, 1024),
+                (1152, 896),
+                (896, 1152),
+                (1216, 832),
+                (832, 1216),
+                (1344, 768),
+                (768, 1344),
+                (1536, 640),
+                (640, 1536),
+            ]
 
-        if not resolutions:
+            # Filter resolutions smaller than bbox, and any that could result in a total pixel size smaller than the current inpaint dimensions.
+            resolutions = [
+                res
+                for res in resolutions
+                if (res[0] >= bbox_width and res[1] >= bbox_height)
+                and (res[0] >= inpaint_width or res[1] >= inpaint_height)
+            ]
+
+            if not resolutions:
+                return (inpaint_width, inpaint_height)
+
+            optimal_resolution = min(
+                resolutions,
+                key=lambda res: abs((res[0] / res[1]) - bbox_aspect_ratio),
+            )
+        elif calculate_optimal_crop.startswith("Free"):
+            prefer_larger = calculate_optimal_crop.endswith("(prefer larger sizes)")
+
+            scale_size = max(inpaint_width, inpaint_height) if prefer_larger else min(inpaint_width, inpaint_height)
+
+            if bbox_aspect_ratio > 1:
+                optimal_width = scale_size * bbox_aspect_ratio
+                optimal_height = scale_size
+            else:
+                optimal_height = scale_size / bbox_aspect_ratio
+                optimal_width = scale_size
+
+            # Round up to the nearest multiple of 8 to make the dimensions friendly for upscaling/diffusion.
+            optimal_width = ((optimal_width + 8 - 1) // 8) * 8
+            optimal_height = ((optimal_height + 8 - 1) // 8) * 8
+
+            optimal_resolution = (int(optimal_width), int(optimal_height))
+        else:
+            msg = (
+                "[-] ADetailer: unsupported inpaint bounding box match mode. Original inpainting dimensions will be used."
+            )
+            print(msg)
+
+        if optimal_resolution is None:
             return (inpaint_width, inpaint_height)
 
-        optimal_resolution = min(
-            resolutions,
-            key=lambda res: abs((res[0] / res[1]) - (bbox_width / bbox_height)),
-        )
-
-        if optimal_resolution != (inpaint_width, inpaint_height):
+        # Only use optimal dimensions if they're different enough to current inpaint dimensions.
+        if (abs(optimal_resolution[0] - inpaint_width) > inpaint_width * 0.1 and abs(optimal_resolution[1] - inpaint_height) > inpaint_height * 0.1):
             print(
                 f"[-] ADetailer: inpaint dimensions optimized -- {inpaint_width}x{inpaint_height} -> {optimal_resolution[0]}x{optimal_resolution[1]}"
             )
@@ -1010,11 +1041,13 @@ def on_ui_settings():
     shared.opts.add_option(
         "ad_match_inpaint_bbox_size",
         shared.OptionInfo(
-            False,
-            "Try to match inpainting size to bounding box size, if 'Use separate width/height' is not set",
+            default="Off",
+            component=gr.Radio,
+            component_args={"choices": INPAINT_BBOX_MATCH_MODES},
+            label="Try to match inpainting size to bounding box size, if 'Use separate width/height' is not set",
             section=section,
         ).info(
-            "Works with SDXL only, as it natively supports alternative aspect ratios"
+            "Strict is for SDXL only, and matches exactly to trained SDXL resolutions. Free works with any model, but will use potentially unsupported dimensions. Prefer smaller is more conservative and safer."
         ),
     )
 

--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 import platform
 import re
 import sys

--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple, cast
 import gradio as gr
 from PIL import Image, ImageChops
 from rich import print
+import math
 
 import modules
 from aaaaaa.conditional import create_binary_mask, schedulers
@@ -668,6 +669,68 @@ class AfterDetailerScript(scripts.Script):
             width, height = p.width, p.height
         return images.resize_image(p.resize_mode, mask, width, height)
 
+    @staticmethod
+    def get_dynamic_denoise_strength(denoise_strength, bbox, image):
+        denoise_power = opts.data.get("ad_dynamic_denoise_power", 0)
+        if math.isclose(denoise_power, 0):
+            return denoise_strength
+
+        image_pixels = image.width * image.height
+        bbox_pixels = (bbox[2] - bbox[0]) * (bbox[3] - bbox[1])
+
+        normalized_area = bbox_pixels / image_pixels
+        denoise_modifier = (1.0 - normalized_area) ** denoise_power
+
+        print((f"[-] ADetailer: dynamic denoising -- {denoise_modifier:.2f} * {denoise_strength:.2f} = {denoise_strength * denoise_modifier:.2f}"))
+        
+        return denoise_strength * denoise_modifier
+
+    @staticmethod
+    def get_optimal_crop_image_size(inpaint_width, inpaint_height, bbox):
+        calculate_optimal_crop = opts.data.get("ad_match_inpaint_bbox_size", False)
+        if not calculate_optimal_crop:
+            return (inpaint_width, inpaint_height)
+
+        resolutions = []
+        if shared.sd_model.is_sdxl:
+            # Limit resolutions to those SDXL was trained on.
+            resolutions = [ 
+                (1024, 1024),
+                (1152, 896), (896, 1152),
+                (1216, 832), (832, 1216),
+                (1344, 768), (768, 1344),
+                (1536, 640), (640, 1536)
+            ]
+        else:
+            msg = (
+                "[-] ADetailer: inpaint bounding box size matching is only valid for SDXL."
+            )
+            print(msg)
+            return (inpaint_width, inpaint_height)
+
+        bbox_width = bbox[2] - bbox[0]
+        bbox_height = bbox[3] - bbox[1]
+
+        target_aspect = bbox_width / bbox_height
+        larger_resolutions = [res for res in resolutions if res[0] >= bbox_width and res[1] >= bbox_height]
+        
+        if not larger_resolutions:
+            return (inpaint_width, inpaint_height)
+        
+        def aspect_ratio_difference(res):
+            res_aspect = res[0] / res[1]
+            return abs(res_aspect - target_aspect)
+        
+        optimal_resolution = min(larger_resolutions, key=aspect_ratio_difference)
+
+        # Don't use resolution if it's smaller than what was to be used.
+        if optimal_resolution[0] < inpaint_width and optimal_resolution[1] < inpaint_height:
+            return (inpaint_width, inpaint_height)
+        
+        print((f"[-] ADetailer: inpaint dimensions optimized -- {inpaint_width}x{inpaint_height} -> {optimal_resolution[0]:.0f}x{optimal_resolution[1]:.0f}"))
+
+        return optimal_resolution
+
     @rich_traceback
     def process(self, p, *args_):
         if getattr(p, "_ad_disabled", False):
@@ -773,6 +836,10 @@ class AfterDetailerScript(scripts.Script):
 
             p2.cached_c = [None, None]
             p2.cached_uc = [None, None]
+            
+            p2.denoising_strength = self.get_dynamic_denoise_strength(p2.denoising_strength, pred.bboxes[j], pp.image)
+            p2.width, p2.height = self.get_optimal_crop_image_size(p2.width, p2.height, pred.bboxes[j])
+
             try:
                 processed = process_images(p2)
             except NansException as e:
@@ -915,6 +982,25 @@ def on_ui_settings():
         ),
     )
 
+    shared.opts.add_option(
+        "ad_dynamic_denoise_power",
+        shared.OptionInfo(
+            default=0,
+            label="Power scaling for dynamic denoise strength based on bounding box size",
+            component=gr.Slider,
+            component_args={"minimum": -10, "maximum": 10, "step": 0.01},
+            section=section,
+        )
+        .info("Smaller areas get higher denoising, larger areas less. Maximum denoise strength is set by 'Inpaint denoising strength'. 0 = disabled; 1 = linear; 4 = recommended"),
+    )
+
+    shared.opts.add_option(
+        "ad_match_inpaint_bbox_size",
+        shared.OptionInfo(
+            False, "Try to match inpaint width, height and aspect ratio to bounding box size", section=section
+        )
+        .info("SDXL only, as it natively supports alternative aspect ratios"),
+    )
 
 # xyz_grid
 

--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -764,7 +764,7 @@ class AfterDetailerScript(scripts.Script):
         # Only use optimal dimensions if they're different enough to current inpaint dimensions.
         if (
             abs(optimal_resolution[0] - inpaint_width) > inpaint_width * 0.1
-            and abs(optimal_resolution[1] - inpaint_height) > inpaint_height * 0.1
+            or abs(optimal_resolution[1] - inpaint_height) > inpaint_height * 0.1
         ):
             print(
                 f"[-] ADetailer: inpaint dimensions optimized -- {inpaint_width}x{inpaint_height} -> {optimal_resolution[0]}x{optimal_resolution[1]}"

--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -715,13 +715,19 @@ class AfterDetailerScript(scripts.Script):
 
         # Filter resolutions smaller than bbox, and any that could result in a total pixel size smaller than the current inpaint dimensions.
         resolutions = [
-            res for res in resolutions if (res[0] >= bbox_width and res[1] >= bbox_height) and (res[0] >= inpaint_width or res[1] >= inpaint_height)
+            res
+            for res in resolutions
+            if (res[0] >= bbox_width and res[1] >= bbox_height)
+            and (res[0] >= inpaint_width or res[1] >= inpaint_height)
         ]
 
         if not resolutions:
             return (inpaint_width, inpaint_height)
 
-        optimal_resolution = min(resolutions, key=lambda res: abs((res[0] / res[1]) - (bbox_width / bbox_height)))
+        optimal_resolution = min(
+            resolutions,
+            key=lambda res: abs((res[0] / res[1]) - (bbox_width / bbox_height)),
+        )
 
         if optimal_resolution != (inpaint_width, inpaint_height):
             print(
@@ -1007,7 +1013,9 @@ def on_ui_settings():
             False,
             "Try to match inpainting size to bounding box size, if 'Use separate width/height' is not set",
             section=section,
-        ).info("Works with SDXL only, as it natively supports alternative aspect ratios"),
+        ).info(
+            "Works with SDXL only, as it natively supports alternative aspect ratios"
+        ),
     )
 
 


### PR DESCRIPTION
This commit adds two features I've personally found useful, but I'm unsure if they would be beneficial to others. I thought I'd create a pull request to see if there's any interest in them, and to make sure they work correctly on other configurations.

## Dynamic denoising strength
Denoising strength is a difficult value to tune, as the amount of denoising is often linked to the size of the inpaint region, with smaller areas requiring stronger denoising, and larger areas less.

This is my attempt to try and somewhat automate denoising strength tweaking. Basically, I take the pixel area of the bbox and the area of the original image, normalise the value, and apply power scaling to it. This value is then multiplied by the "Inpaint denoising strength" value (which effectively sets the maximum denoising value). 

I've found this approach very effective at modulating the denoise strength, and it can modulate it per bbox, so that if there are multiple areas of different sizes in the one image, the strength is tweaked appropriately for each. Recommended settings:

``Inpaint denoising strength: 0.6 - 0.7`` (now effectively a maximum value, which is scaled down)
``Power scaling value: 2.0-4.0`` (modulates the scaling by a [power curve](https://www.wolframalpha.com/input?i=plot+pow%281-x%2C4%29+from+0+to+1))

By default, the power scaling value is 0, which disables the feature. It also supports negative values for the sake of completeness, but I found in testing you usually want a sharp drop off in denoising strength between small and large areas.

## Match inpaint dimensions to bbox size
If the user doesn't specify their own inpaint width and height, the original dimensions of the image are used, which makes complete sense. However, it's often the case these dimensions are at odds with those of the bbox, resulting in a sub-optimal inpainting region.

With models like SDXL, that natively support alternate aspect ratios, we can calculate a better width and height from the bbox, and use that instead. It's highly likely you could come up with some resolutions for other models too; SDXL is the only model I've tested with (and so this feature is limited to SDXL only).