### PR TITLE
Add CMD flag functionality for model path

### DIFF
--- a/preload.py
+++ b/preload.py
@@ -8,8 +8,8 @@ def preload(parser: argparse.ArgumentParser):
         help="Don't use adetailer models from huggingface",
     )
     parser.add_argument(
-        "--adetailer-dir", 
-        type=str, 
-        help="directory with adetailer models", 
-        default=None
+        "--adetailer-dir",
+        type=str,
+        help="directory with adetailer models",
+        default=None,
     )

--- a/preload.py
+++ b/preload.py
@@ -7,3 +7,9 @@ def preload(parser: argparse.ArgumentParser):
         action="store_true",
         help="Don't use adetailer models from huggingface",
     )
+    parser.add_argument(
+        "--adetailer-dir", 
+        type=str, 
+        help="directory with adetailer models", 
+        default=None
+    )

--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -84,7 +84,7 @@ if TYPE_CHECKING:
 PARAMS_TXT = "params.txt"
 
 no_huggingface = getattr(cmd_opts, "ad_no_huggingface", False)
-adetailer_dir = Path(paths.models_path, "adetailer")
+adetailer_dir = shared.cmd_opts.adetailer_dir or Path(paths.models_path, "adetailer")
 safe_mkdir(adetailer_dir)
 
 extra_models_dirs = shared.opts.data.get("ad_extra_models_dir", "")


### PR DESCRIPTION
Usage:

`--adetailer-dir "c:\path\to\models"`

It's something I add personally for a while now, as I have a lot of different instances of automatic1111 and forge and want to keep my models centralized. 

It's an alternative to symlinks. 

Up to you if you want to merge or close it, just a suggestion.