### PR TITLE
Let load classes for YOLO models

### DIFF
--- a/aaaaaa/ui.py
+++ b/aaaaaa/ui.py
@@ -97,7 +97,7 @@ def on_ad_model_update(model: str):
             visible=True,
             placeholder="Comma separated class names to detect, ex: 'person,cat'. default: COCO 80 classes",
         )
-    elif "yolo" in model.lower():
+    if "yolo" in model.lower():
         return gr.update(
             visible=True,
             placeholder="Comma separated class numbers to detect or separated class names, ex: '0,1' for first 2 classes, or 'head, hip",

--- a/aaaaaa/ui.py
+++ b/aaaaaa/ui.py
@@ -97,6 +97,11 @@ def on_ad_model_update(model: str):
             visible=True,
             placeholder="Comma separated class names to detect, ex: 'person,cat'. default: COCO 80 classes",
         )
+    elif "yolo" in model.lower():
+        return gr.update(
+            visible=True,
+            placeholder="Comma separated class numbers to detect or separated class names, ex: '0,1' for first 2 classes, or 'head, hip",
+        )
     return gr.update(visible=False, placeholder="")
 
 
@@ -203,7 +208,7 @@ def one_ui_group(n: int, is_img2img: bool, webui_info: WebuiInfo):
             w.ad_model_classes = gr.Textbox(
                 label="ADetailer detector classes" + suffix(n),
                 value="",
-                visible=False,
+                visible=True,
                 elem_id=eid("ad_model_classes"),
             )
 


### PR DESCRIPTION
Actually, when using models from example from https://github.com/aperveyev/booru_yolo/tree/main/models, it uses all classes when it founds it.
This PR lets the user set a class index or number to use that class instead of every class.
For now it prints all classes found, but only uses the one that the user entered.