### PR TITLE
Set upper bound for ultralytics version

### DIFF
--- a/install.py
+++ b/install.py
@@ -8,9 +8,7 @@ from importlib.metadata import version  # python >= 3.8
 from packaging.version import parse
 
 import_name = {"py-cpuinfo": "cpuinfo", "protobuf": "google.protobuf"}
-custom_requirements = {
-    "ultralytics": "ultralytics>=8.3.0,<=8.3.40"
-}
+custom_requirements = {"ultralytics": "ultralytics>=8.3.0,<=8.3.40"}
 excluded_versions = {"ultralytics": ("8.3.41", "8.3.42", "8.3.45", "8.3.46")}
 
 

--- a/install.py
+++ b/install.py
@@ -9,7 +9,7 @@ from packaging.version import parse
 
 import_name = {"py-cpuinfo": "cpuinfo", "protobuf": "google.protobuf"}
 custom_requirements = {
-    "ultralytics": "ultralytics>=8.3.0,!=8.3.41,!=8.3.42,!=8.3.45,!=8.3.46"
+    "ultralytics": "ultralytics>=8.3.0,<=8.3.40"
 }
 excluded_versions = {"ultralytics": ("8.3.41", "8.3.42", "8.3.45", "8.3.46")}
 


### PR DESCRIPTION
I think the ultralytics issue might go on for longer than expected.

 To prevent future intrusions until a post-mortem / solution is implemented properly from ultralytics side, we set the upper version to .40 instead which is the last known safe version. Future versions are not to be trusted since the event is ongoing.