### PR TITLE
add "Use ADetailer only for hires-fix" setting

### DIFF
--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -771,14 +771,14 @@ class AfterDetailerScript(scripts.Script):
     def process(self, p, *args_):
         if getattr(p, "_ad_disabled", False):
             return
-        
-        if not getattr(p, "enable_hr", False) and shared.opts.data.get("ad_use_only_for_hires_fix", False):
+
+        if not getattr(p, "enable_hr", False) and shared.opts.data.get(
+            "ad_use_only_for_hires_fix", False
+        ):
             p._ad_disabled = True
-            msg = (
-                "[-] ADetailer: ADetailer is only enabled for high-res fix. You can change this behavior in the settings."
-            )
+            msg = "[-] ADetailer: ADetailer is only enabled for high-res fix. You can change this behavior in the settings."
             print(msg)
-            return        
+            return
 
         if is_img2img_inpaint(p) and is_all_black(self.get_image_mask(p)):
             p._ad_disabled = True
@@ -787,7 +787,7 @@ class AfterDetailerScript(scripts.Script):
             )
             print(msg)
             return
-        
+
         if not self.is_ad_enabled(*args_):
             p._ad_disabled = True
             return
@@ -1071,9 +1071,7 @@ def on_ui_settings():
             default=False,
             label="Use ADetailer only for hires-fix",
             section=section,
-        ).info(
-            "If enabled, ADetailer will be used only for the 'hires-fix'."
-        )
+        ).info("If enabled, ADetailer will be used only for the 'hires-fix'."),
     )
 
 

--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -771,6 +771,14 @@ class AfterDetailerScript(scripts.Script):
     def process(self, p, *args_):
         if getattr(p, "_ad_disabled", False):
             return
+        
+        if not getattr(p, "enable_hr", False) and shared.opts.data.get("ad_use_only_for_hires_fix", False):
+            p._ad_disabled = True
+            msg = (
+                "[-] ADetailer: ADetailer is only enabled for high-res fix. You can change this behavior in the settings."
+            )
+            print(msg)
+            return        
 
         if is_img2img_inpaint(p) and is_all_black(self.get_image_mask(p)):
             p._ad_disabled = True
@@ -779,7 +787,7 @@ class AfterDetailerScript(scripts.Script):
             )
             print(msg)
             return
-
+        
         if not self.is_ad_enabled(*args_):
             p._ad_disabled = True
             return
@@ -1055,6 +1063,17 @@ def on_ui_settings():
         ).info(
             "Strict is for SDXL only, and matches exactly to trained SDXL resolutions. Free works with any model, but will use potentially unsupported dimensions."
         ),
+    )
+
+    shared.opts.add_option(
+        "ad_use_only_for_hires_fix",
+        shared.OptionInfo(
+            default=False,
+            label="Use ADetailer only for hires-fix",
+            section=section,
+        ).info(
+            "If enabled, ADetailer will be used only for the 'hires-fix'."
+        )
     )
 
 


### PR DESCRIPTION
안녕하세요, 개인적으로 있으면 좋겠다 싶은 기능이라서 settings에 "Hires Fix를 이용할 때만 ADetailer가 적용됨"을 추가해 보았습니다.
말 그대로, 일반 이미지 생성시에는 ADetailer가 enabled 상태여도 ADetailer가 적용되지 않으며, 
Hires Fix가 켜져있거나, 혹은 일반 이미지 생성 후 이미지 우하단 별표 Upscale 버튼을 눌렀을 때만 ADetailer가 적용되도록 하는 옵션입니다.

![image](https://github.com/user-attachments/assets/0208654d-8503-4de8-97ee-a1a7ac0ced4f)

default 값은 False이며, 해당 세팅이 켜져있을 시 Hires Fix가 아닌 일반 이미지 생성시 아래와 같은 안내문이 콘솔에 뜨도록 하였습니다.

![image](https://github.com/user-attachments/assets/0c9484d8-1761-47b5-8cb4-a03845013c79)

혹시 괜찮으시다면 merge 고려해주시면 감사합니다!