### PR TITLE
Add Refresh Buttons for Checkpoint/VAE Dropdowns

### DIFF
--- a/aaaaaa/ui.py
+++ b/aaaaaa/ui.py
@@ -541,7 +541,7 @@ def inpainting(w: Widgets, n: int, is_img2img: bool, webui_info: WebuiInfo):  # 
                     create_refresh_button(
                         refresh_component=w.ad_checkpoint, 
                         refresh_method=list_models, 
-                        refreshed_args=lambda: {"choices": ["Use same checkpoint"] + checkpoint_tiles(use_short=True)}, 
+                        refreshed_args=lambda: {"choices": ["Use same checkpoint", *checkpoint_tiles(use_short=True)]}, 
                         elem_id="ad_checkpoint_refresh")
 
             with gr.Column(variant="compact"):
@@ -565,7 +565,7 @@ def inpainting(w: Widgets, n: int, is_img2img: bool, webui_info: WebuiInfo):  # 
                     create_refresh_button(
                         refresh_component=w.ad_vae, 
                         refresh_method=refresh_vae_list, 
-                        refreshed_args=lambda: {"choices": ["Use same VAE"] + sd_vae_items()}, 
+                        refreshed_args=lambda: {"choices": ["Use same VAE", *sd_vae_items()]}, 
                         elem_id="ad_vae_refresh")
 
         with gr.Row(), gr.Column(variant="compact"):

--- a/aaaaaa/ui.py
+++ b/aaaaaa/ui.py
@@ -18,7 +18,6 @@ from adetailer import ADETAILER, __version__
 from adetailer.args import ALL_ARGS, MASK_MERGE_INVERT
 from controlnet_ext import controlnet_exists, controlnet_type, get_cn_models
 
-
 if controlnet_type == "forge":
     from lib_controlnet import global_state
 
@@ -140,13 +139,6 @@ def adui(
         label=ADETAILER,
         visible=True,
     ) as ad_enable:
-        
-        ad_hires_only = gr.Checkbox(
-            value=False, 
-            label="Run on quick Hires Only", 
-            visible=not is_img2img, 
-            elem_id=eid("ad_hires_only"))
-
         with gr.Row():
             with gr.Column(scale=8):
                 ad_skip_img2img = gr.Checkbox(
@@ -177,8 +169,8 @@ def adui(
                 states.append(state)
                 infotext_fields.extend(infofields)
 
-    # components: [bool, bool, bool, dict, dict, ...]
-    components = [ad_enable, ad_hires_only, ad_skip_img2img, *states]
+    # components: [bool, bool, dict, dict, ...]
+    components = [ad_enable, ad_skip_img2img, *states]
     return components, infotext_fields
 
 

--- a/aaaaaa/ui.py
+++ b/aaaaaa/ui.py
@@ -538,10 +538,16 @@ def inpainting(w: Widgets, n: int, is_img2img: bool, webui_info: WebuiInfo):  # 
                         elem_id=eid("ad_checkpoint"),
                     )
                     create_refresh_button(
-                        refresh_component=w.ad_checkpoint, 
-                        refresh_method=list_models, 
-                        refreshed_args=lambda: {"choices": ["Use same checkpoint", *checkpoint_tiles(use_short=True)]}, 
-                        elem_id="ad_checkpoint_refresh")
+                        refresh_component=w.ad_checkpoint,
+                        refresh_method=list_models,
+                        refreshed_args=lambda: {
+                            "choices": [
+                                "Use same checkpoint",
+                                *checkpoint_tiles(use_short=True),
+                            ]
+                        },
+                        elem_id="ad_checkpoint_refresh",
+                    )
 
             with gr.Column(variant="compact"):
                 w.ad_use_vae = gr.Checkbox(
@@ -562,10 +568,13 @@ def inpainting(w: Widgets, n: int, is_img2img: bool, webui_info: WebuiInfo):  # 
                         elem_id=eid("ad_vae"),
                     )
                     create_refresh_button(
-                        refresh_component=w.ad_vae, 
-                        refresh_method=refresh_vae_list, 
-                        refreshed_args=lambda: {"choices": ["Use same VAE", *sd_vae_items()]}, 
-                        elem_id="ad_vae_refresh")
+                        refresh_component=w.ad_vae,
+                        refresh_method=refresh_vae_list,
+                        refreshed_args=lambda: {
+                            "choices": ["Use same VAE", *sd_vae_items()]
+                        },
+                        elem_id="ad_vae_refresh",
+                    )
 
         with gr.Row(), gr.Column(variant="compact"):
             w.ad_use_sampler = gr.Checkbox(

--- a/aaaaaa/ui.py
+++ b/aaaaaa/ui.py
@@ -10,7 +10,7 @@ import gradio as gr
 
 from modules.sd_models import checkpoint_tiles, list_models
 from modules.shared_items import sd_vae_items, refresh_vae_list
-from modules import ui_common
+from modules.ui_common import create_refresh_button
 
 from aaaaaa.conditional import InputAccordion
 from adetailer import ADETAILER, __version__
@@ -538,7 +538,7 @@ def inpainting(w: Widgets, n: int, is_img2img: bool, webui_info: WebuiInfo):  # 
                         visible=True,
                         elem_id=eid("ad_checkpoint"),
                     )
-                    ui_common.create_refresh_button(
+                    create_refresh_button(
                         refresh_component=w.ad_checkpoint, 
                         refresh_method=list_models, 
                         refreshed_args=lambda: {"choices": ["Use same checkpoint"] + checkpoint_tiles(use_short=True)}, 
@@ -562,7 +562,7 @@ def inpainting(w: Widgets, n: int, is_img2img: bool, webui_info: WebuiInfo):  # 
                         visible=True,
                         elem_id=eid("ad_vae"),
                     )
-                    ui_common.create_refresh_button(
+                    create_refresh_button(
                         refresh_component=w.ad_vae, 
                         refresh_method=refresh_vae_list, 
                         refreshed_args=lambda: {"choices": ["Use same VAE"] + sd_vae_items()}, 

--- a/aaaaaa/ui.py
+++ b/aaaaaa/ui.py
@@ -9,8 +9,7 @@ from typing import Any
 import gradio as gr
 
 from modules.sd_models import checkpoint_tiles, list_models
-from modules.sd_vae import refresh_vae_list
-from modules.shared_items import sd_vae_items
+from modules.shared_items import sd_vae_items, refresh_vae_list
 from modules import ui_common
 
 from aaaaaa.conditional import InputAccordion


### PR DESCRIPTION
Addresses #754.

Adds a refresh button to both the `Use Separate Checkpoint` and `Use Separate VAE` dropdowns:
![image](https://github.com/user-attachments/assets/79695282-3a1e-461c-9a49-b79c050c9352)

Tested in both Automatic1111 v1.10 and Forge f2.0.1v1.10. Functions imported from `modules` were last updated prior to WebUI 1.5 so there shouldn't be any compatibility issues.

A couple considerations:
- Does not update `checkpoints_list` and `vae_list` fields in `WebuiInfo` dataclass (this can be changed if required)
- Refreshing a checkpoint/vae dropdown does not refresh the dropdowns in other adetailer tabs