### PR TITLE
Fix torch.load with pytorch 2.6

### DIFF
--- a/aaaaaa/helper.py
+++ b/aaaaaa/helper.py
@@ -32,7 +32,7 @@ def change_torch_load():
     try:
         # Force weights_only=False (True by default in pytorch>=2.6)
         def custom_load(*args, **kwargs):
-            kwargs['weights_only'] = False
+            kwargs["weights_only"] = False
             return safe.unsafe_torch_load(*args, **kwargs)
 
         torch.load = custom_load

--- a/aaaaaa/helper.py
+++ b/aaaaaa/helper.py
@@ -30,7 +30,12 @@ PT = Union[StableDiffusionProcessingTxt2Img, StableDiffusionProcessingImg2Img]
 def change_torch_load():
     orig = torch.load
     try:
-        torch.load = safe.unsafe_torch_load
+        # Force weights_only=False (True by default in pytorch>=2.6)
+        def custom_load(*args, **kwargs):
+            kwargs['weights_only'] = False
+            return safe.unsafe_torch_load(*args, **kwargs)
+
+        torch.load = custom_load
         yield
     finally:
         torch.load = orig


### PR DESCRIPTION
In this version, weights_only argument of torch.load now defaults to True [0], which breaks adetailer with yolo8 models.

This change forces weights_only=False (previous default value) to workaround the issue, now that pytorch 2.6 is stable.

Issues #739 and #767

[0] https://dev-discuss.pytorch.org/t/bc-breaking-change-torch-load-is-being-flipped-to-use-weights-only-true-by-default-in-the-nightlies-after-137602/2573