### PR TITLE
Adjust builtin scripts for advanced model sampling (reforge)

### DIFF
--- a/adetailer/args.py
+++ b/adetailer/args.py
@@ -282,7 +282,12 @@ _script_default = (
 )
 SCRIPT_DEFAULT = ",".join(sorted(_script_default))
 
-_builtin_script = ("soft_inpainting", "hypertile_script")
+_builtin_script = (
+    "advanced_model_sampling_script",
+    "advanced_model_sampling_script_backported",
+    "hypertile_script",
+    "soft_inpainting",
+)
 BUILTIN_SCRIPT = ",".join(sorted(_builtin_script))
 
 


### PR DESCRIPTION
Required for models using Advanced Model Sampling for operations.

Flow models using SD3 sampling method get discarded:
<img width="680" height="754" alt="image" src="https://github.com/user-attachments/assets/2bde98e0-8cae-4f17-aaef-b255298a7891" />

After adding AMS to builtin in works:
<img width="1099" height="1092" alt="image" src="https://github.com/user-attachments/assets/ac1df1ac-d811-4353-8fb4-c4e7aaa46396" />
