### PR TITLE
fix(helper): allow disable_safe_unpickle on environments without cmd_opts.disable_safe_unpickle

### DIFF
--- a/aaaaaa/helper.py
+++ b/aaaaaa/helper.py
@@ -42,7 +42,7 @@ def change_torch_load():
 def disable_safe_unpickle():
     with (
         patch.dict(os.environ, {"TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD": "1"}, clear=False),
-        patch.object(cmd_opts, "disable_safe_unpickle", True),
+        patch.object(cmd_opts, "disable_safe_unpickle", True, create=True),
     ):
         yield
 


### PR DESCRIPTION
## What

Adds `create=True` to the `patch.object(cmd_opts, "disable_safe_unpickle", True)` call inside the `disable_safe_unpickle` context manager in `aaaaaa/helper.py`.

```diff
- patch.object(cmd_opts, "disable_safe_unpickle", True),
+ patch.object(cmd_opts, "disable_safe_unpickle", True, create=True),
```

## Why

Forge Neo ships a slimmer `modules.shared.cmd_opts` that doesn't expose the `disable_safe_unpickle` attribute. Without `create=True`, `unittest.mock.patch.object` raises `AttributeError: <Namespace> does not have the attribute 'disable_safe_unpickle'` the first time ADetailer tries to load a detection model, and detection fails for the rest of the session.

The fix is a single kwarg documented in [`unittest.mock.patch.object`](https://docs.python.org/3/library/unittest.mock.html#patch-object): when `create=True`, the attribute is materialised at patch time if it doesn't already exist.

## Behavioural impact

- **Environment where `cmd_opts.disable_safe_unpickle` already exists (regular A1111, Forge, etc.)**: byte-identical behaviour — `create=True` is a no-op in that case.
- **Environment where the attribute is missing (Forge Neo)**: instead of `AttributeError` → the attribute is created and patched with the value `True`, then restored on context exit. ADetailer loads models normally.

No new dependencies. No API changes. No infotext changes.

## Test plan

- ✅ Manual test on Forge Neo (Stability Matrix, Python 3.13.12, neo-2.24): before the patch ADetailer raised `AttributeError` at first model load; after, models load and inpaint passes run cleanly.
- ✅ Manual test on regular Forge (Python 3.10): behaviour unchanged, no regression.

Could not add an automated test because the existing test suite mocks `cmd_opts` differently — happy to add one if you have a preferred shape.

## Related

This change is part of a broader maintained fork of adetailer (https://github.com/xXIlRizzoXx/adetailer-ultimate). I'm submitting this one fix in isolation per the discussion at #845.

Thanks for considering 🙏