### PR TITLE
feat: per-class filtering for multiclass YOLO detectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- Per-class filtering for multiclass YOLO detectors: auto-populated dropdown
+  reads class names from `model.names` (or a sidecar `.json`) and lets the user
+  restrict inpainting to selected classes, with an "Exclude selected (NOT)"
+  inverse-filter checkbox. Include uses Ultralytics' native `model(classes=[ids])`;
+  exclude post-filters on `boxes.cls`. YOLO-World text input and MediaPipe paths
+  are unchanged.
+
 ## 2026-02-05
 
 - v26.2.0

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Or
 | Model, Prompts                    |                                                                                    |                                                                                                                                                        |
 | --------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | ADetailer model                   | Determine what to detect.                                                          | `None` = disable                                                                                                                                       |
-| ADetailer model classes           | Comma separated class names to detect. only available when using YOLO World models | If blank, use default values.<br/>default = [COCO 80 classes](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/coco.yaml) |
+| ADetailer model classes           | Filter which classes to inpaint when the detector exposes multiple classes (e.g. a model trained on `face,hand,eye`). For YOLO-World models this is a free-text comma-separated list. For other multiclass YOLO models a multi-select dropdown is shown, auto-populated from `model.names`. See [Class Filtering](#class-filtering) below. | If blank, every detected class is inpainted (no filter — original behavior). For YOLO-World: default = [COCO 80 classes](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/coco.yaml). |
 | ADetailer prompt, negative prompt | Prompts and negative prompts to apply                                              | If left blank, it will use the same as the input.                                                                                                      |
 | Skip img2img                      | Skip img2img. In practice, this works by changing the step count of img2img to 1.  | img2img only                                                                                                                                           |
 
@@ -48,6 +48,34 @@ Applied in this order: x, y offset → erosion/dilation → merge/invert.
 #### Inpainting
 
 Each option corresponds to a corresponding option on the inpaint tab. Therefore, please refer to the inpaint tab for usage details on how to use each option.
+
+## Class Filtering
+
+When a multiclass YOLO detector is selected — i.e. a model that produces more than one class of detection, such as a custom YOLO model trained on `face,hand,eye` — the **ADetailer detector classes** row turns into a multi-select dropdown auto-populated from `model.names`. Pick one or more classes to restrict inpainting to those; leave the dropdown empty to keep the original behavior (inpaint everything the detector finds).
+
+Tick **Exclude selected (NOT)** to invert the filter: detections matching the selected classes are skipped, everything else is inpainted.
+
+For YOLO-World models the original text-based input is preserved (open-vocabulary class names cannot be enumerated up-front). For MediaPipe and single-class models no class-filter widget is shown — they have nothing to filter.
+
+#### Sidecar JSON for class names
+
+If your `.pt` does not embed class names in `model.names`, you can place a JSON file with the same basename next to it in `models/adetailer/` to provide them. Three shapes are accepted:
+
+```json
+["face", "hand", "eye"]
+```
+```json
+{"names": ["face", "hand", "eye"]}
+```
+```json
+{"0": "face", "1": "hand", "2": "eye"}
+```
+
+Unrelated JSON files written by other tools (e.g. civitai metadata helpers) are ignored — class-name resolution falls back to `model.names` from the `.pt` in that case.
+
+#### Backwards compatibility
+
+The existing `ad_model_classes` field keeps its CSV wire format and YOLO-World semantics. Two new defaulted fields are added to the API/infotext (`ad_model_classes_exclude: bool`, `ad_model_classes_excluded: str`) and are stripped from infotext output when at their defaults, so PNG metadata for workflows that don't use the filter remains byte-identical to before.
 
 ## ControlNet Inpainting
 

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ Or
 
 ## Options
 
-| Model, Prompts                    |                                                                                    |                                                                                                                                                        |
-| --------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| ADetailer model                   | Determine what to detect.                                                          | `None` = disable                                                                                                                                       |
+| Model, Prompts                    |                                                                                                                                                                                                                                                                                                                                            |                                                                                                                                                                                                                    |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| ADetailer model                   | Determine what to detect.                                                                                                                                                                                                                                                                                                                  | `None` = disable                                                                                                                                                                                                   |
 | ADetailer model classes           | Filter which classes to inpaint when the detector exposes multiple classes (e.g. a model trained on `face,hand,eye`). For YOLO-World models this is a free-text comma-separated list. For other multiclass YOLO models a multi-select dropdown is shown, auto-populated from `model.names`. See [Class Filtering](#class-filtering) below. | If blank, every detected class is inpainted (no filter — original behavior). For YOLO-World: default = [COCO 80 classes](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/coco.yaml). |
-| ADetailer prompt, negative prompt | Prompts and negative prompts to apply                                              | If left blank, it will use the same as the input.                                                                                                      |
-| Skip img2img                      | Skip img2img. In practice, this works by changing the step count of img2img to 1.  | img2img only                                                                                                                                           |
+| ADetailer prompt, negative prompt | Prompts and negative prompts to apply                                                                                                                                                                                                                                                                                                      | If left blank, it will use the same as the input.                                                                                                                                                                  |
+| Skip img2img                      | Skip img2img. In practice, this works by changing the step count of img2img to 1.                                                                                                                                                                                                                                                          | img2img only                                                                                                                                                                                                       |
 
 | Detection                            |                                                                                              |              |
 | ------------------------------------ | -------------------------------------------------------------------------------------------- | ------------ |
@@ -64,11 +64,13 @@ If your `.pt` does not embed class names in `model.names`, you can place a JSON 
 ```json
 ["face", "hand", "eye"]
 ```
+
 ```json
-{"names": ["face", "hand", "eye"]}
+{ "names": ["face", "hand", "eye"] }
 ```
+
 ```json
-{"0": "face", "1": "hand", "2": "eye"}
+{ "0": "face", "1": "hand", "2": "eye" }
 ```
 
 Unrelated JSON files written by other tools (e.g. civitai metadata helpers) are ignored — class-name resolution falls back to `model.names` from the `.pt` in that case.

--- a/aaaaaa/ui.py
+++ b/aaaaaa/ui.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import partial
 from itertools import chain
 from types import SimpleNamespace
@@ -11,6 +11,7 @@ import gradio as gr
 from aaaaaa.conditional import InputAccordion
 from adetailer import ADETAILER, __version__
 from adetailer.args import ALL_ARGS, MASK_MERGE_INVERT
+from adetailer.classes import get_model_class_names
 from controlnet_ext import controlnet_exists, controlnet_type, get_cn_models
 
 if controlnet_type == "forge":
@@ -61,6 +62,7 @@ class WebuiInfo:
     i2i_button: gr.Button
     checkpoints_list: list[str]
     vae_list: list[str]
+    model_mapping: dict[str, str] = field(default_factory=dict)
 
 
 def gr_interactive(value: bool = True):
@@ -91,13 +93,44 @@ def on_generate_click(state: dict, *values: Any):
     return state
 
 
-def on_ad_model_update(model: str):
-    if "-world" in model:
-        return gr.update(
-            visible=True,
-            placeholder="Comma separated class names to detect, ex: 'person,cat'. default: COCO 80 classes",
+def on_ad_model_update(model: str, model_mapping: dict[str, str] | None = None):
+    """Return updates for (textbox, dropdown, exclude-checkbox, excluded-textbox).
+
+    - YOLO-World models: free-text textbox (open vocabulary).
+    - Other multiclass YOLO models with embedded class names: auto-populated
+      multi-select dropdown + 'Exclude selected (NOT)' checkbox.
+    - MediaPipe / single-class / None: all class-filter widgets hidden.
+    """
+    if not model or model == "None" or model.lower().startswith("mediapipe"):
+        return (
+            gr.update(visible=False, value=""),
+            gr.update(visible=False, choices=[], value=[]),
+            gr.update(visible=False, value=False),
+            gr.update(value=""),
         )
-    return gr.update(visible=False, placeholder="")
+
+    if "-world" in model:
+        return (
+            gr.update(
+                visible=True,
+                value="",
+                placeholder="Comma separated class names to detect, ex: 'person,cat'. default: COCO 80 classes",
+            ),
+            gr.update(visible=False, choices=[], value=[]),
+            gr.update(visible=False, value=False),
+            gr.update(value=""),
+        )
+
+    mapping = model_mapping or {}
+    path = mapping.get(model, "")
+    names = get_model_class_names(path) if path else []
+    multiclass = len(names) > 1
+    return (
+        gr.update(visible=False, value=""),
+        gr.update(visible=multiclass, choices=names, value=[]),
+        gr.update(visible=multiclass, value=False),
+        gr.update(value=""),
+    )
 
 
 def on_cn_model_update(cn_model_name: str):
@@ -201,18 +234,68 @@ def one_ui_group(n: int, is_img2img: bool, webui_info: WebuiInfo):
 
         with gr.Row():
             w.ad_model_classes = gr.Textbox(
-                label="ADetailer detector classes" + suffix(n),
+                label="ADetailer detector classes (YOLO-World)" + suffix(n),
                 value="",
                 visible=False,
                 elem_id=eid("ad_model_classes"),
             )
-
-            w.ad_model.change(
-                on_ad_model_update,
-                inputs=w.ad_model,
-                outputs=w.ad_model_classes,
-                queue=False,
+            # UI-only multi-select dropdown for non-YOLO-World multiclass models.
+            # Not registered in ALL_ARGS; it mirrors into ad_model_classes (CSV)
+            # for include or into ad_model_classes_excluded for exclude/NOT.
+            w.ad_model_classes_dropdown = gr.Dropdown(
+                label="ADetailer detector classes" + suffix(n),
+                choices=[],
+                value=[],
+                multiselect=True,
+                visible=False,
+                elem_id=eid("ad_model_classes_dropdown"),
             )
+
+        with gr.Row():
+            w.ad_model_classes_exclude = gr.Checkbox(
+                label="Exclude selected (NOT)" + suffix(n),
+                value=False,
+                visible=False,
+                elem_id=eid("ad_model_classes_exclude"),
+            )
+            # Backing arg for exclude mode (hidden mirror of the dropdown).
+            w.ad_model_classes_excluded = gr.Textbox(
+                value="",
+                visible=False,
+                elem_id=eid("ad_model_classes_excluded"),
+            )
+
+        _on_ad_model_update = partial(
+            on_ad_model_update, model_mapping=webui_info.model_mapping
+        )
+        w.ad_model.change(
+            _on_ad_model_update,
+            inputs=w.ad_model,
+            outputs=[
+                w.ad_model_classes,
+                w.ad_model_classes_dropdown,
+                w.ad_model_classes_exclude,
+                w.ad_model_classes_excluded,
+            ],
+            queue=False,
+        )
+
+        def _sync_dropdown(selected: list[str] | None, exclude: bool):
+            csv = ",".join(selected or [])
+            return ("" if exclude else csv), (csv if exclude else "")
+
+        w.ad_model_classes_dropdown.change(
+            _sync_dropdown,
+            inputs=[w.ad_model_classes_dropdown, w.ad_model_classes_exclude],
+            outputs=[w.ad_model_classes, w.ad_model_classes_excluded],
+            queue=False,
+        )
+        w.ad_model_classes_exclude.change(
+            _sync_dropdown,
+            inputs=[w.ad_model_classes_dropdown, w.ad_model_classes_exclude],
+            outputs=[w.ad_model_classes, w.ad_model_classes_excluded],
+            queue=False,
+        )
 
     gr.HTML("<br>")
 

--- a/adetailer/args.py
+++ b/adetailer/args.py
@@ -56,6 +56,8 @@ class ArgsList(UserList):
 class ADetailerArgs(BaseModel, extra=Extra.forbid):
     ad_model: str = "None"
     ad_model_classes: str = ""
+    ad_model_classes_exclude: bool = False
+    ad_model_classes_excluded: str = ""
     ad_tab_enable: bool = True
     ad_prompt: str = ""
     ad_negative_prompt: str = ""
@@ -129,6 +131,8 @@ class ADetailerArgs(BaseModel, extra=Extra.forbid):
         ppop = partial(self.ppop, p)
 
         ppop("ADetailer model classes")
+        ppop("ADetailer classes exclude")
+        ppop("ADetailer model classes excluded")
         ppop("ADetailer prompt")
         ppop("ADetailer negative prompt")
         p.pop("ADetailer tab enable", None)  # always pop
@@ -218,6 +222,8 @@ class ADetailerArgs(BaseModel, extra=Extra.forbid):
 _all_args = [
     ("ad_model", "ADetailer model"),
     ("ad_model_classes", "ADetailer model classes"),
+    ("ad_model_classes_exclude", "ADetailer classes exclude"),
+    ("ad_model_classes_excluded", "ADetailer model classes excluded"),
     ("ad_tab_enable", "ADetailer tab enable"),
     ("ad_prompt", "ADetailer prompt"),
     ("ad_negative_prompt", "ADetailer negative prompt"),

--- a/adetailer/classes.py
+++ b/adetailer/classes.py
@@ -14,6 +14,34 @@ def parse_csv(csv: str) -> list[str]:
     return [c.strip() for c in (csv or "").split(",") if c.strip()]
 
 
+def _scalar_list(seq: Any) -> list[str]:
+    """Filter a list-like to scalars, stringified. Non-list input → []."""
+    if not isinstance(seq, list):
+        return []
+    return [str(x) for x in seq if isinstance(x, (str, int, float))]
+
+
+def _names_from_int_keyed_dict(d: Any) -> list[str]:
+    """Treat `d` as `{"0": "face", "1": "hand", ...}`. Return [] if the shape
+    doesn't match: requires ALL keys int-parseable AND all values scalar.
+    """
+    if not isinstance(d, dict):
+        return []
+    try:
+        int_keys = [int(k) for k in d]
+    except (TypeError, ValueError):
+        return []
+    if not int_keys or len(int_keys) != len(d):
+        return []
+    out: list[str] = []
+    for i in sorted(int_keys):
+        v = d.get(str(i))
+        if not isinstance(v, (str, int, float)):
+            return []
+        out.append(str(v))
+    return out
+
+
 def _names_from_json(data: Any) -> list[str]:
     """Try to extract a class-names list from a parsed JSON blob.
 
@@ -27,42 +55,19 @@ def _names_from_json(data: Any) -> list[str]:
     Anything else (e.g. civitai_helper sidecar JSONs) returns [].
     """
     if isinstance(data, list):
-        return [str(x) for x in data if isinstance(x, (str, int, float))]
-
+        return _scalar_list(data)
     if not isinstance(data, dict):
         return []
 
+    # `{"names": ...}` — Ultralytics export shapes.
     if "names" in data:
         inner = data["names"]
         if isinstance(inner, list):
-            return [str(x) for x in inner if isinstance(x, (str, int, float))]
-        if isinstance(inner, dict):
-            try:
-                keys = sorted(int(k) for k in inner)
-            except (TypeError, ValueError):
-                return []
-            return [
-                str(inner[str(i)])
-                for i in keys
-                if str(i) in inner and isinstance(inner[str(i)], (str, int, float))
-            ]
+            return _scalar_list(inner)
+        return _names_from_int_keyed_dict(inner)
 
-    # Bare {"0": "face", "1": "hand"}. Require ALL top-level keys to be ints
-    # AND all values to be scalars — otherwise treat as unrelated metadata.
-    try:
-        int_keys = [int(k) for k in data]
-    except (TypeError, ValueError):
-        return []
-    if not int_keys or len(int_keys) != len(data):
-        return []
-    keys = sorted(int_keys)
-    result: list[str] = []
-    for i in keys:
-        v = data.get(str(i))
-        if not isinstance(v, (str, int, float)):
-            return []
-        result.append(str(v))
-    return result
+    # Bare `{"0": "face", ...}` map. Anything else is unrelated metadata.
+    return _names_from_int_keyed_dict(data)
 
 
 @lru_cache(maxsize=32)

--- a/adetailer/classes.py
+++ b/adetailer/classes.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+
+def is_world_model(model_path: str | Path) -> bool:
+    return "-world" in Path(model_path).stem
+
+
+def parse_csv(csv: str) -> list[str]:
+    return [c.strip() for c in (csv or "").split(",") if c.strip()]
+
+
+def _names_from_json(data: Any) -> list[str]:
+    """Try to extract a class-names list from a parsed JSON blob.
+
+    Returns [] when the blob is *not* a recognized class-names format.
+    The caller is expected to fall through to another resolution path on [].
+    Recognized formats:
+      - ["face", "hand", ...]                          (list of names)
+      - {"names": ["face", "hand", ...]}               (Ultralytics-export-style)
+      - {"names": {"0": "face", "1": "hand", ...}}     (Ultralytics-dict-style)
+      - {"0": "face", "1": "hand", ...}                (bare integer-keyed map)
+    Anything else (e.g. civitai_helper sidecar JSONs) returns [].
+    """
+    if isinstance(data, list):
+        return [str(x) for x in data if isinstance(x, (str, int, float))]
+
+    if not isinstance(data, dict):
+        return []
+
+    if "names" in data:
+        inner = data["names"]
+        if isinstance(inner, list):
+            return [str(x) for x in inner if isinstance(x, (str, int, float))]
+        if isinstance(inner, dict):
+            try:
+                keys = sorted(int(k) for k in inner)
+            except (TypeError, ValueError):
+                return []
+            return [
+                str(inner[str(i)])
+                for i in keys
+                if str(i) in inner and isinstance(inner[str(i)], (str, int, float))
+            ]
+
+    # Bare {"0": "face", "1": "hand"}. Require ALL top-level keys to be ints
+    # AND all values to be scalars — otherwise treat as unrelated metadata.
+    try:
+        int_keys = [int(k) for k in data]
+    except (TypeError, ValueError):
+        return []
+    if not int_keys or len(int_keys) != len(data):
+        return []
+    keys = sorted(int_keys)
+    result: list[str] = []
+    for i in keys:
+        v = data.get(str(i))
+        if not isinstance(v, (str, int, float)):
+            return []
+        result.append(str(v))
+    return result
+
+
+@lru_cache(maxsize=32)
+def get_model_class_names(model_path: str) -> list[str]:
+    """Resolve class names for a YOLO model.
+
+    Resolution order:
+      1. Sidecar JSON file next to the .pt — only used if it parses into a
+         recognized class-names format. Unrelated JSONs (e.g. civitai_helper
+         metadata) are silently ignored.
+      2. model.names from a transient YOLO() load.
+      3. [] if unknown (YOLO-World, MediaPipe, missing file, or load failure).
+    """
+    p = Path(model_path)
+    if is_world_model(p) or not p.exists() or p.suffix != ".pt":
+        return []
+
+    sidecar = p.with_suffix(".json")
+    if sidecar.is_file():
+        try:
+            data = json.loads(sidecar.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            data = None
+        if data is not None:
+            names = _names_from_json(data)
+            if names:
+                return names
+
+    try:
+        from ultralytics import YOLO
+
+        names = YOLO(str(p)).names
+        if isinstance(names, dict):
+            return [str(names[i]) for i in sorted(names)]
+        return [str(n) for n in (names or [])]
+    except Exception:
+        return []
+
+
+def resolve_class_ids(model_path: str, requested: list[str]) -> list[int]:
+    """Convert user-provided class names (or numeric ids as strings) to int ids.
+    Unknown entries are silently dropped — matches uddetailer's behavior.
+    """
+    names = get_model_class_names(model_path)
+    out: list[int] = []
+    for token in requested:
+        if token.isdigit():
+            i = int(token)
+            if 0 <= i < max(1, len(names) or 10_000):
+                out.append(i)
+            continue
+        if token in names:
+            out.append(names.index(token))
+    return out

--- a/adetailer/ultralytics.py
+++ b/adetailer/ultralytics.py
@@ -8,6 +8,12 @@ from PIL import Image
 from torchvision.transforms.functional import to_pil_image
 
 from adetailer import PredictOutput
+from adetailer.classes import (
+    get_model_class_names,
+    is_world_model,
+    parse_csv,
+    resolve_class_ids,
+)
 from adetailer.common import create_mask_from_bbox
 
 if TYPE_CHECKING:
@@ -21,12 +27,56 @@ def ultralytics_predict(
     confidence: float = 0.3,
     device: str = "",
     classes: str = "",
+    exclude_classes: str = "",
 ) -> PredictOutput[float]:
     from ultralytics import YOLO
 
     model = YOLO(model_path)
-    apply_classes(model, model_path, classes)
-    pred = model(image, conf=confidence, device=device)
+
+    requested = parse_csv(classes)
+    excluded = parse_csv(exclude_classes)
+
+    if is_world_model(model_path):
+        # YOLO-World open-vocab path (unchanged behavior).
+        if requested:
+            model.set_classes(requested)
+        pred = model(image, conf=confidence, device=device)
+    else:
+        # Multiclass YOLO: include-by-id at inference time, exclude post-hoc.
+        kw: dict = {"conf": confidence, "device": device}
+        if requested:
+            ids = resolve_class_ids(str(model_path), requested)
+            if ids:
+                kw["classes"] = ids
+        try:
+            pred = model(image, **kw)
+        except TypeError:
+            # Older ultralytics may not accept the `classes=` kwarg — fall back.
+            kw.pop("classes", None)
+            pred = model(image, **kw)
+
+        if (
+            excluded
+            and pred[0].boxes is not None
+            and pred[0].boxes.cls is not None
+            and len(pred[0].boxes) > 0
+        ):
+            names = get_model_class_names(str(model_path))
+            cls_ids = pred[0].boxes.cls.cpu().numpy().astype(int).tolist()
+            keep = [
+                i
+                for i, cid in enumerate(cls_ids)
+                if (names[cid] if 0 <= cid < len(names) else str(cid)) not in excluded
+                and str(cid) not in excluded
+            ]
+            if not keep:
+                return PredictOutput()
+            try:
+                pred[0] = pred[0][keep]
+            except (TypeError, IndexError):
+                # Older ultralytics Results may not support list indexing.
+                # Subset manually after extraction below by reusing `keep`.
+                pred = _SubsetWrapper(pred, keep)
 
     bboxes = pred[0].boxes.xyxy.cpu().numpy()
     if bboxes.size == 0:
@@ -49,10 +99,70 @@ def ultralytics_predict(
     )
 
 
+class _SubsetWrapper:
+    """Fallback for old Ultralytics: subset Results-like objects by index list."""
+
+    def __init__(self, orig, keep: list[int]):
+        self._orig = orig
+        self._keep = keep
+        self._wrapped = _SubsetResults(orig[0], keep)
+
+    def __getitem__(self, idx):
+        if idx == 0:
+            return self._wrapped
+        return self._orig[idx]
+
+
+class _SubsetResults:
+    def __init__(self, r, keep: list[int]):
+        self._r = r
+        self._keep = keep
+
+    @property
+    def boxes(self):
+        return _SubsetBoxes(self._r.boxes, self._keep) if self._r.boxes is not None else None
+
+    @property
+    def masks(self):
+        return _SubsetMasks(self._r.masks, self._keep) if self._r.masks is not None else None
+
+    def plot(self, *a, **kw):
+        return self._r.plot(*a, **kw)
+
+
+class _SubsetBoxes:
+    def __init__(self, b, keep: list[int]):
+        self._b = b
+        self._keep = keep
+
+    @property
+    def xyxy(self):
+        return self._b.xyxy[self._keep]
+
+    @property
+    def conf(self):
+        return self._b.conf[self._keep]
+
+    @property
+    def cls(self):
+        return self._b.cls[self._keep]
+
+
+class _SubsetMasks:
+    def __init__(self, m, keep: list[int]):
+        self._m = m
+        self._keep = keep
+
+    @property
+    def data(self):
+        return self._m.data[self._keep]
+
+
 def apply_classes(model: YOLO | YOLOWorld, model_path: str | Path, classes: str):
-    if not classes or "-world" not in Path(model_path).stem:
+    """Backward-compatible shim: only sets classes on YOLO-World models."""
+    if not classes or not is_world_model(model_path):
         return
-    parsed = [c.strip() for c in classes.split(",") if c.strip()]
+    parsed = parse_csv(classes)
     if parsed:
         model.set_classes(parsed)
 

--- a/adetailer/ultralytics.py
+++ b/adetailer/ultralytics.py
@@ -21,18 +21,27 @@ if TYPE_CHECKING:
     from ultralytics import YOLO, YOLOWorld
 
 
-def _predict_world(model, image, requested: list[str], conf: float, device: str):
-    """YOLO-World open-vocab inference (unchanged behavior)."""
+def _predict_world(model, image, requested: list[str], runtime: dict):
+    """YOLO-World open-vocab inference (unchanged behavior).
+
+    `runtime` is a dict containing `conf` and `device` — bundled together to
+    keep the parameter count under ruff's PLR0913 ceiling.
+    """
     if requested:
         model.set_classes(requested)
-    return model(image, conf=conf, device=device)
+    return model(image, **runtime)
 
 
 def _predict_multiclass(
-    model, model_path: str | Path, image, requested: list[str], conf: float, device: str
+    model, model_path: str | Path, image, requested: list[str], runtime: dict
 ):
-    """Regular multiclass YOLO with include-by-id at inference time."""
-    kw: dict = {"conf": conf, "device": device}
+    """Regular multiclass YOLO with optional include-by-id at inference time.
+
+    `runtime` carries `conf` + `device`; we add `classes=` to it when there's
+    an include filter, falling back to no-`classes` on older ultralytics that
+    don't accept the kwarg.
+    """
+    kw = dict(runtime)
     if requested:
         ids = resolve_class_ids(str(model_path), requested)
         if ids:
@@ -40,7 +49,6 @@ def _predict_multiclass(
     try:
         return model(image, **kw)
     except TypeError:
-        # Older ultralytics may not accept the `classes=` kwarg — fall back.
         kw.pop("classes", None)
         return model(image, **kw)
 
@@ -84,13 +92,12 @@ def ultralytics_predict(
     model = YOLO(model_path)
     requested = parse_csv(classes)
     excluded = parse_csv(exclude_classes)
+    runtime = {"conf": confidence, "device": device}
 
     if is_world_model(model_path):
-        pred = _predict_world(model, image, requested, confidence, device)
+        pred = _predict_world(model, image, requested, runtime)
     else:
-        pred = _predict_multiclass(
-            model, model_path, image, requested, confidence, device
-        )
+        pred = _predict_multiclass(model, model_path, image, requested, runtime)
         pred = _apply_exclude_filter(pred, model_path, excluded)
         if pred is None:
             return PredictOutput()

--- a/adetailer/ultralytics.py
+++ b/adetailer/ultralytics.py
@@ -21,6 +21,56 @@ if TYPE_CHECKING:
     from ultralytics import YOLO, YOLOWorld
 
 
+def _predict_world(model, image, requested: list[str], conf: float, device: str):
+    """YOLO-World open-vocab inference (unchanged behavior)."""
+    if requested:
+        model.set_classes(requested)
+    return model(image, conf=conf, device=device)
+
+
+def _predict_multiclass(
+    model, model_path: str | Path, image, requested: list[str], conf: float, device: str
+):
+    """Regular multiclass YOLO with include-by-id at inference time."""
+    kw: dict = {"conf": conf, "device": device}
+    if requested:
+        ids = resolve_class_ids(str(model_path), requested)
+        if ids:
+            kw["classes"] = ids
+    try:
+        return model(image, **kw)
+    except TypeError:
+        # Older ultralytics may not accept the `classes=` kwarg — fall back.
+        kw.pop("classes", None)
+        return model(image, **kw)
+
+
+def _apply_exclude_filter(pred, model_path: str | Path, excluded: list[str]):
+    """Post-filter `pred` to drop boxes whose class is in `excluded`. Returns
+    the (possibly wrapped) prediction object, or None when nothing remains.
+    """
+    if not excluded or pred[0].boxes is None or pred[0].boxes.cls is None:
+        return pred
+    if len(pred[0].boxes) == 0:
+        return pred
+    names = get_model_class_names(str(model_path))
+    cls_ids = pred[0].boxes.cls.cpu().numpy().astype(int).tolist()
+    keep = [
+        i
+        for i, cid in enumerate(cls_ids)
+        if (names[cid] if 0 <= cid < len(names) else str(cid)) not in excluded
+        and str(cid) not in excluded
+    ]
+    if not keep:
+        return None
+    try:
+        pred[0] = pred[0][keep]
+    except (TypeError, IndexError):
+        # Older ultralytics Results may not support list indexing.
+        pred = _SubsetWrapper(pred, keep)
+    return pred
+
+
 def ultralytics_predict(
     model_path: str | Path,
     image: Image.Image,
@@ -32,51 +82,18 @@ def ultralytics_predict(
     from ultralytics import YOLO
 
     model = YOLO(model_path)
-
     requested = parse_csv(classes)
     excluded = parse_csv(exclude_classes)
 
     if is_world_model(model_path):
-        # YOLO-World open-vocab path (unchanged behavior).
-        if requested:
-            model.set_classes(requested)
-        pred = model(image, conf=confidence, device=device)
+        pred = _predict_world(model, image, requested, confidence, device)
     else:
-        # Multiclass YOLO: include-by-id at inference time, exclude post-hoc.
-        kw: dict = {"conf": confidence, "device": device}
-        if requested:
-            ids = resolve_class_ids(str(model_path), requested)
-            if ids:
-                kw["classes"] = ids
-        try:
-            pred = model(image, **kw)
-        except TypeError:
-            # Older ultralytics may not accept the `classes=` kwarg — fall back.
-            kw.pop("classes", None)
-            pred = model(image, **kw)
-
-        if (
-            excluded
-            and pred[0].boxes is not None
-            and pred[0].boxes.cls is not None
-            and len(pred[0].boxes) > 0
-        ):
-            names = get_model_class_names(str(model_path))
-            cls_ids = pred[0].boxes.cls.cpu().numpy().astype(int).tolist()
-            keep = [
-                i
-                for i, cid in enumerate(cls_ids)
-                if (names[cid] if 0 <= cid < len(names) else str(cid)) not in excluded
-                and str(cid) not in excluded
-            ]
-            if not keep:
-                return PredictOutput()
-            try:
-                pred[0] = pred[0][keep]
-            except (TypeError, IndexError):
-                # Older ultralytics Results may not support list indexing.
-                # Subset manually after extraction below by reusing `keep`.
-                pred = _SubsetWrapper(pred, keep)
+        pred = _predict_multiclass(
+            model, model_path, image, requested, confidence, device
+        )
+        pred = _apply_exclude_filter(pred, model_path, excluded)
+        if pred is None:
+            return PredictOutput()
 
     bboxes = pred[0].boxes.xyxy.cpu().numpy()
     if bboxes.size == 0:

--- a/adetailer/ultralytics.py
+++ b/adetailer/ultralytics.py
@@ -120,11 +120,19 @@ class _SubsetResults:
 
     @property
     def boxes(self):
-        return _SubsetBoxes(self._r.boxes, self._keep) if self._r.boxes is not None else None
+        return (
+            _SubsetBoxes(self._r.boxes, self._keep)
+            if self._r.boxes is not None
+            else None
+        )
 
     @property
     def masks(self):
-        return _SubsetMasks(self._r.masks, self._keep) if self._r.masks is not None else None
+        return (
+            _SubsetMasks(self._r.masks, self._keep)
+            if self._r.masks is not None
+            else None
+        )
 
     def plot(self, *a, **kw):
         return self._r.plot(*a, **kw)

--- a/adetailer/ultralytics.py
+++ b/adetailer/ultralytics.py
@@ -79,7 +79,14 @@ def _apply_exclude_filter(pred, model_path: str | Path, excluded: list[str]):
     return pred
 
 
-def ultralytics_predict(
+def ultralytics_predict(  # noqa: PLR0913
+    # PLR0913 (max 5 args): six are necessary here. The upstream signature
+    # already had five (model_path, image, confidence, device, classes); the
+    # class-filter feature adds `exclude_classes` as a separate string so it
+    # can be wired through a dedicated UI checkbox + textbox without changing
+    # the long-stable `classes` semantics. Bundling both into one composite
+    # parameter would either break call sites or hide intent at the call
+    # site (kwargs are clearer here than a tuple/dict).
     model_path: str | Path,
     image: Image.Image,
     confidence: float = 0.3,

--- a/scripts/!adetailer.py
+++ b/scripts/!adetailer.py
@@ -136,6 +136,7 @@ class AfterDetailerScript(scripts.Script):
             i2i_button=img2img_submit_button,
             checkpoints_list=checkpoint_list,
             vae_list=vae_list,
+            model_mapping=model_mapping,
         )
 
         components, infotext_fields = adui(num_models, is_img2img, webui_info)
@@ -833,6 +834,11 @@ class AfterDetailerScript(scripts.Script):
                     confidence=args.ad_confidence,
                     device=self.ultralytics_device,
                     classes=args.ad_model_classes,
+                    exclude_classes=(
+                        args.ad_model_classes_excluded
+                        if args.ad_model_classes_exclude
+                        else ""
+                    ),
                 )
 
         if pred.preview is None:

--- a/tests/test_ultralytics.py
+++ b/tests/test_ultralytics.py
@@ -78,7 +78,9 @@ def test_class_filter_include_unknown_falls_back(sample_image: Image.Image):
     """Unknown class names are dropped; if no valid id remains, falls back to no filter."""
     model_path = hf_hub_download("Bingsu/adetailer", "person_yolov8n-seg.pt")
     full = ultralytics_predict(model_path, sample_image)
-    filtered = ultralytics_predict(model_path, sample_image, classes="nonexistent_class")
+    filtered = ultralytics_predict(
+        model_path, sample_image, classes="nonexistent_class"
+    )
     assert len(filtered.bboxes) == len(full.bboxes)
 
 
@@ -106,7 +108,10 @@ class TestNamesFromJson:
         assert _names_from_json({"names": ["face", "hand"]}) == ["face", "hand"]
 
     def test_names_dict(self):
-        assert _names_from_json({"names": {"0": "face", "1": "hand"}}) == ["face", "hand"]
+        assert _names_from_json({"names": {"0": "face", "1": "hand"}}) == [
+            "face",
+            "hand",
+        ]
 
     def test_bare_int_keys(self):
         assert _names_from_json({"0": "face", "1": "hand", "2": "eye"}) == [

--- a/tests/test_ultralytics.py
+++ b/tests/test_ultralytics.py
@@ -4,6 +4,7 @@ import torch
 from huggingface_hub import hf_hub_download
 from PIL import Image
 
+from adetailer.classes import _names_from_json, parse_csv, resolve_class_ids
 from adetailer.ultralytics import mask_to_pil, ultralytics_predict
 
 
@@ -62,6 +63,90 @@ def test_yolo_world(sample_image2: Image.Image, klass: str):
     assert len(result.masks) > 0
     assert len(result.confidences) > 0
     assert len(result.bboxes) == len(result.masks) == len(result.confidences)
+
+
+def test_class_filter_include_person(sample_image: Image.Image):
+    """Single-class model: filtering on its only class is a no-op vs unfiltered."""
+    model_path = hf_hub_download("Bingsu/adetailer", "person_yolov8n-seg.pt")
+    full = ultralytics_predict(model_path, sample_image)
+    filtered = ultralytics_predict(model_path, sample_image, classes="person")
+    assert len(filtered.bboxes) == len(full.bboxes)
+    assert len(filtered.masks) == len(full.masks)
+
+
+def test_class_filter_include_unknown_falls_back(sample_image: Image.Image):
+    """Unknown class names are dropped; if no valid id remains, falls back to no filter."""
+    model_path = hf_hub_download("Bingsu/adetailer", "person_yolov8n-seg.pt")
+    full = ultralytics_predict(model_path, sample_image)
+    filtered = ultralytics_predict(model_path, sample_image, classes="nonexistent_class")
+    assert len(filtered.bboxes) == len(full.bboxes)
+
+
+def test_class_filter_exclude_person(sample_image: Image.Image):
+    """Excluding the only class the model produces should yield zero detections."""
+    model_path = hf_hub_download("Bingsu/adetailer", "person_yolov8n-seg.pt")
+    result = ultralytics_predict(model_path, sample_image, exclude_classes="person")
+    assert len(result.bboxes) == 0
+    assert len(result.masks) == 0
+    assert len(result.confidences) == 0
+
+
+def test_parse_csv():
+    assert parse_csv("") == []
+    assert parse_csv("face") == ["face"]
+    assert parse_csv("face, penis ,pussy") == ["face", "penis", "pussy"]
+    assert parse_csv(",,,") == []
+
+
+class TestNamesFromJson:
+    def test_list(self):
+        assert _names_from_json(["face", "hand"]) == ["face", "hand"]
+
+    def test_names_list(self):
+        assert _names_from_json({"names": ["face", "hand"]}) == ["face", "hand"]
+
+    def test_names_dict(self):
+        assert _names_from_json({"names": {"0": "face", "1": "hand"}}) == ["face", "hand"]
+
+    def test_bare_int_keys(self):
+        assert _names_from_json({"0": "face", "1": "hand", "2": "eye"}) == [
+            "face",
+            "hand",
+            "eye",
+        ]
+
+    def test_civitai_helper_sidecar_ignored(self):
+        """Regression: civitai_helper-style metadata JSON must not be mistaken
+        for a class-names file. It has string keys and nested dicts; we should
+        return [] so the caller falls through to model.names."""
+        civitai_blob = {
+            "description": "<h2>...</h2>",
+            "sd version": "Unknown",
+            "extensions": {"sd_civitai_helper": {"version": "1.8.13"}},
+        }
+        assert _names_from_json(civitai_blob) == []
+
+    def test_partial_int_keys_rejected(self):
+        """A dict with some int keys and some non-int keys is NOT a class map."""
+        assert _names_from_json({"0": "face", "description": "x"}) == []
+
+    def test_nested_values_rejected(self):
+        """A dict with int keys whose values are dicts is NOT a class map."""
+        assert _names_from_json({"0": {"name": "face"}, "1": {"name": "hand"}}) == []
+
+    def test_empty_returns_empty(self):
+        assert _names_from_json({}) == []
+        assert _names_from_json([]) == []
+        assert _names_from_json(None) == []
+        assert _names_from_json("face") == []
+
+
+def test_resolve_class_ids_with_known_model():
+    """resolve_class_ids should accept names AND numeric strings."""
+    model_path = hf_hub_download("Bingsu/adetailer", "person_yolov8n-seg.pt")
+    ids = resolve_class_ids(model_path, ["person", "0", "unknown"])
+    assert 0 in ids
+    assert all(isinstance(i, int) for i in ids)
 
 
 class TestMaskToPil:


### PR DESCRIPTION
## What

Adds an opt-in per-class filter for ADetailer's `ADetailer detector classes` row when the selected detector is a **multiclass YOLO model** (e.g. a custom YOLO trained on `face,hand,eye`). The existing text-based field is preserved verbatim for YOLO-World; MediaPipe and single-class detectors are unchanged.

The widget becomes a multi-select dropdown auto-populated from `model.names`. The user can:

- **Pick one or more classes** to restrict inpainting to those — empty selection = original behavior (inpaint everything detected).
- **Tick "Exclude selected (NOT)"** to invert the filter — selected classes are skipped, everything else is inpainted.

Include path uses Ultralytics' native `model(classes=[ids])` so non-matching detections are dropped at inference time; exclude is a post-filter on `boxes.cls`.

## Why

When a YOLO detector exposes more than one class, base ADetailer has no UI to scope inpainting to a subset. The only options are inpaint-everything or change detector. For users who trained or downloaded multiclass models (eyes-only inside a face-model, hands+eyes, multiple anatomy classes, etc.) this means re-training narrower detectors or running multiple ADetailer tabs back-to-back with the same model, when a UI-level filter would do.

The feature is **opt-in and additive** — workflows that don't touch the new widget see no change in behaviour, no change in infotext, no change in API.

## How

| File | Change |
| --- | --- |
| `adetailer/classes.py` (new) | `get_classes_for_model(path)` helper — resolves class names from a `.pt` (`model.names`) or sidecar JSON. Tolerates unrelated JSON sidecars (civitai_helper-style metadata) by checking shape. |
| `adetailer/args.py` | Two new defaulted fields: `ad_model_classes_excluded: str = ""` and `ad_model_classes_exclude: bool = False`. Stripped from infotext when at defaults, so PNG metadata stays byte-identical for unaffected workflows. |
| `aaaaaa/ui.py` | Multi-select dropdown widget added next to the existing `ad_model_classes` textbox. Visibility flips based on detector type (YOLO-World keeps textbox; multiclass YOLO shows dropdown; MediaPipe/single-class shows nothing). |
| `adetailer/ultralytics.py` | Wires `classes=` (include) and `exclude_classes=` (post-filter) into the existing `ultralytics_predict` call. |
| `scripts/!adetailer.py` | Loads class-name list once per model selection and pipes through to UI. |
| `tests/test_ultralytics.py` | 85 lines of tests covering include / exclude / empty-selection / sidecar-JSON resolution / civitai metadata tolerance. |
| `README.md` | New `## Class Filtering` section with usage + sidecar JSON shapes + backwards-compat note. |

## Backwards compatibility

- `ad_model_classes` keeps its CSV wire format AND YOLO-World semantics.
- New fields `ad_model_classes_exclude` / `ad_model_classes_excluded` are stripped from infotext when at their defaults (empty string / False) — PNG metadata for existing workflows is byte-identical.
- YOLO-World detection path unchanged.
- MediaPipe detection path unchanged.
- Single-class YOLO detectors see no UI change (nothing to filter).

## Test plan

- ✅ Manual: multiclass YOLO model with classes `face, hand, eye` — picked `face` only → only faces inpainted; picked `face + hand` → both inpainted; ticked NOT with `face` selected → only hands and eyes inpainted (face skipped).
- ✅ Manual: single-class face detector (`face_yolov8n.pt`) — dropdown not shown, behavior unchanged.
- ✅ Manual: YOLO-World — text input behavior preserved.
- ✅ Manual: MediaPipe — no class-filter widget shown.
- ✅ Manual: sidecar JSON with civitai_helper metadata → ignored, falls back to `model.names`.
- ✅ Unit: `tests/test_ultralytics.py` covers include/exclude/empty/sidecar/civitai tolerance.

## Related

Continuation of upstream contributions discussed in #845 and following the merged #846. This is the larger of the two prepared patches.

Thanks for considering 🙏