### PR TITLE
fix(install): keep the host's NumPy 1.x when installing dependencies

### DIFF
--- a/install.py
+++ b/install.py
@@ -43,6 +43,26 @@ def run_pip(*args):
     subprocess.run([sys.executable, "-m", "pip", "install", *args], check=True)
 
 
+def numpy_pin() -> list[str]:
+    """Keep the host's NumPy major version when installing our deps.
+
+    On WebUIs pinned to NumPy 1.x (e.g. AUTOMATIC1111 — its gradio 3 / skimage /
+    blendmodes stack requires numpy<2) a fresh install of recent
+    ultralytics/mediapipe drags NumPy up to 2.x, which breaks the whole WebUI
+    with a binary-incompatibility crash. Passing this constraint tells pip's
+    resolver to pick dependency versions compatible with the existing NumPy.
+    No constraint on NumPy 2.x hosts (Forge Neo) or when NumPy isn't importable.
+    """
+    try:
+        import numpy
+
+        if int(numpy.__version__.split(".")[0]) < 2:
+            return ["numpy<2"]
+    except Exception:
+        pass
+    return []
+
+
 def install():
     deps = [
         # requirements
@@ -65,7 +85,7 @@ def install():
             pkgs.append(cmd)
 
     if pkgs:
-        run_pip(*pkgs)
+        run_pip(*pkgs, *numpy_pin())
 
 
 try:


### PR DESCRIPTION
### Problem

On WebUIs pinned to NumPy 1.x — notably **AUTOMATIC1111**, whose `gradio 3` / `skimage` / `blendmodes` stack requires `numpy<2` — a fresh install of this extension's dependencies (`ultralytics` / `mediapipe`) lets pip pull **NumPy 2.x**. That breaks the whole WebUI with a binary-incompatibility crash:

```
ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
```

Reproduced on a clean **AUTOMATIC1111 v1.10.1** install: installing the deps pulled `numpy 2.2.6` (via `mediapipe` / `opencv-contrib-python`), and the WebUI then failed to start (`skimage` import crash; `gradio 3.41.2` also requires `numpy~=1.0`).

### Fix

When the host already has NumPy 1.x, pass a `numpy<2` constraint to the **same** `pip install` so the resolver keeps the existing NumPy and picks compatible dependency versions. No constraint is added on NumPy-2.x hosts (e.g. Forge / Forge Neo) or when NumPy isn't importable yet, so those are unaffected.

Small, self-contained change to `install.py`.

---
_Prepared with the help of Claude (Anthropic's AI); please review as you would any patch. 🤖 Generated with [Claude Code](https://claude.com/claude-code)_
