### PR TITLE
fix(controlnet): fall back to the standard backend on any Forge-shim import error

### DIFF
--- a/controlnet_ext/__init__.py
+++ b/controlnet_ext/__init__.py
@@ -5,7 +5,7 @@ try:
         controlnet_type,
         get_cn_models,
     )
-except Exception:  # noqa: BLE001
+except Exception:
     # Not just ImportError: a broken/drifted Forge lib_controlnet can raise
     # NameError/AttributeError at import time (e.g. reForge). Degrade to the
     # A1111 standard ControlNet backend instead of crashing the whole

--- a/controlnet_ext/__init__.py
+++ b/controlnet_ext/__init__.py
@@ -5,7 +5,11 @@ try:
         controlnet_type,
         get_cn_models,
     )
-except ImportError:
+except Exception:  # noqa: BLE001
+    # Not just ImportError: a broken/drifted Forge lib_controlnet can raise
+    # NameError/AttributeError at import time (e.g. reForge). Degrade to the
+    # A1111 standard ControlNet backend instead of crashing the whole
+    # extension at load (universal-WebUI-compat guard).
     from .controlnet_ext import (
         ControlNetExt,
         controlnet_exists,


### PR DESCRIPTION
### Problem

The Forge-vs-A1111 ControlNet dispatcher in `controlnet_ext/__init__.py` only catches `ImportError` when importing the Forge shim (`controlnet_ext_forge` → `lib_controlnet`). A broken or drifted `lib_controlnet` can raise a **non-`ImportError`** at import time — e.g. a `NameError` raised from its module-level class bodies (observed on **reForge**) — which escapes the fallback and takes the **whole extension** down at load.

### Fix

Widen the fallback to `except Exception` so any import-time failure of the Forge shim degrades gracefully to the A1111 standard ControlNet backend, instead of crashing the extension at load. One-line change (plus an explanatory comment).

---
_Prepared with the help of Claude (Anthropic's AI); please review as you would any patch. 🤖 Generated with [Claude Code](https://claude.com/claude-code)_
